### PR TITLE
Update DanaRS-Insulin-Pump.md

### DIFF
--- a/docs/EN/Configuration/DanaRS-Insulin-Pump.md
+++ b/docs/EN/Configuration/DanaRS-Insulin-Pump.md
@@ -1,6 +1,7 @@
 # DanaRS Pump
 
 _These instructions are for configuring the app and your pump if you have a DanaRS from 2017 onwards. Visit [DanaR Insulin Pump](./DanaR-Insulin-Pump) if you have the original DanaR instead._
+*  In DanaRS pump "BASAL A" is used by the app. Existing data gets overwritten.
 
 *  In AndroidAPS go to Config Builder and select 'DanaRS'
 


### PR DESCRIPTION
Inform that Basal A is used by the app. This allows the user to make a backup of his data upfront (in case he uses already Basal A).