### PR TITLE
Update Open-APS-features.md

### DIFF
--- a/docs/EN/Usage/Open-APS-features.md
+++ b/docs/EN/Usage/Open-APS-features.md
@@ -101,11 +101,11 @@ If you have this option enabled, the insulin sensitivity will be decreased while
  
 **Always use short average delta instead of simple data** If you enable this feature, AndroidAPS uses the short average delta/blood glucose from the last 15 minutes, which is usually the average of the last three values. This helps AndroidAPS to work more steady with noisy data sources like xDrip+ and Libre.
   
-**Max daily safety multiplier** This is an important safety limit. The default setting (which is unlikely to need adjusting) is 3. This means that AndroidAPS will never be allowed to set a temporary basal rate that is more than 3x the highest hourly basal rate programmed in a user’s pump, or, if enabled, determined by autotune. Example: if your highest basal rate is 1.0 U/h and max daily safety multiplier is 3, then AndroidAPS can set a maximum temporary basal rate of 3.0 U/h (= 3 x 1.0 U/h).
+**Max daily safety multiplier** This is an important safety limit. The default setting (which is unlikely to need adjusting) is 3. This means that AndroidAPS will never be allowed to set a temporary basal rate that is more than 3x the highest hourly basal rate programmed in a user’s pump. Example: if your highest basal rate is 1.0 U/h and max daily safety multiplier is 3, then AndroidAPS can set a maximum temporary basal rate of 3.0 U/h (= 3 x 1.0 U/h).
  
 Default value: 3 (shouldn’t be changed unless you really need to and know, what you are doing)
   
-**Current Basal safety multiplier** This is another important safety limit. The default setting (which is also unlikely to need adjusting) is 4. This means that AndroidAPS will never be allowed to set a temporary basal rate that is more than 4x the current hourly basal rate programmed in a user’s pump, or, if enabled, determined by autotune.
+**Current Basal safety multiplier** This is another important safety limit. The default setting (which is also unlikely to need adjusting) is 4. This means that AndroidAPS will never be allowed to set a temporary basal rate that is more than 4x the current hourly basal rate programmed in a user’s pump.
  
 Default value: 4 (shouldn’t be changed unless you really need to and know, what you are doing) 
 


### PR DESCRIPTION
I deleted the highlighted text from screenshot.

In AndroidAPS, autotune will not automatically adjust the basal rate programmed in a user's pump (as opposed to OpenAPS) and therefore I consider that part redundant and confusing.

![knipsel](https://user-images.githubusercontent.com/46421525/50738422-f3595380-11d3-11e9-84a2-7b8fdf650290.JPG)
