### PR TITLE
Update Preferences.md

### DIFF
--- a/docs/EN/Configuration/Preferences.md
+++ b/docs/EN/Configuration/Preferences.md
@@ -4,14 +4,13 @@
 This allows you to set a password in order to prevent accidental or unauthorised changes to Preferences. After you enter a password here you will be required to enter it in order to access Preferences.  To remove the password option then when within the Preferences delete the text within this field.
 
 ## Patient age
-There are security limits in place based on age you selected in this setting. If you start hitting this hard limits (like max bolus) it's time move one step up. It's bad idea to select higher then real age because it can lead to overdosing by entering the wrong value in insulin dialog (by skipping the decimal dot, for example).
+There are security limits in place based on age you selected in this setting. If you start hitting this hard limits (like max bolus) it's time move one step up. It's bad idea to select higher then real age because it can lead to overdosing by entering the wrong value in insulin dialog (by skipping the decimal dot, for example). If you want to know the actual numbers for these hard coded security limits, scroll to the algorithm feature you are using on [this page](../Usage/Open-APS-features.md).
 
 ## General
-* Select your language here.  If your language is not available, or not all of the words are translated then feel free to make some suggestions on [Crowdin](https://crowdin.com/project/androidaps) or ask in the [gitter chatroom](https://gitter.im/MilosKozak/AndroidAPS).
-* Quick Wizard settings allows you to add a quick button for a frequent snack or meal, enter your decided carb details and on the homescreen if you select the quick wizard button it will calculate and bolus for those carbs based on your current ratios (taking into account blood glucose value or insulin on board if set up).
+Select your language here.  If your language is not available, or not all of the words are translated then feel free to make some suggestions on [Crowdin](https://crowdin.com/project/androidaps) or ask in the [gitter chatroom](https://gitter.im/MilosKozak/AndroidAPS).
 
-## Careportal
-'Entered by' is the text displayed in your nightscout careportal 'entered by' field.  Set this to something meaningful to you, whether it is the app name, the person's name or the phone name (for example if you are using AndroidAPS as NS Client on a phone that is not the patient's phone you may wish to distinguish between phone owners here).
+## Overview
+Is described in the Overview section of [this](../Configuration/Config-Builder.md) page.
 
 ## Treatments safety
 


### PR DESCRIPTION
Added some info:
1) In Patient Age section: Added link to OpenAPS features, where the actual values of hard coded limits per patient age can be found.

Aligned wiki text with version 2.0 of AAPS:
2) General section: Removed text about Quick Wizard settings. 
3) Careportal section: Removed.
4) Overview section (newly created): With link to Config Builder where this section is already explained.