### PR TITLE
Update BG-Source.md - minor adjustments and typo's

### DIFF
--- a/docs/EN/Configuration/BG-Source.md
+++ b/docs/EN/Configuration/BG-Source.md
@@ -17,7 +17,7 @@
 
 ### If using G4 with OTG cable ('traditional' Nightscout)…<br>
 * If not already set up then download Nightscout Uploader app from the Play Store and follow instructions on [Nightscout](http://www.nightscout.info/wiki/welcome/basic-requirements).
-* In AndroidAPS Preferences enter your nightscout website and API secret.
+* In AndroidAPS Preferences enter your Nightscout website and API secret.
 * Select NSClient in ConfigBuilder (setting in AndroidAPS).
 
 ## For users of Libre with Bluetooth cap<br>
@@ -37,7 +37,7 @@ To use your Libre as a CGM that is getting new BG values every 5 minutes you fir
 * For G5 native mode in xdrip go to Settings > Cloud upload > REST API > Extra options > Append source info to device and select ON.
 
 ### If using Glimp...<br>
-* If not already set up then download Glimp and follow instructions on [nightscout](http://www.nightscout.info/wiki/welcome/nightscout-for-libre).
+* If not already set up then download Glimp and follow instructions on [Nightscout](http://www.nightscout.info/wiki/welcome/nightscout-for-libre).
 * Select Glimp in ConfigBuilder (setting in AndroidAPS).
 
 ## For users of Eversense<br>
@@ -45,12 +45,12 @@ The easiest way to use Eversense with AndroidAPS is to install the modified [Eve
 
 **Warning: by uninstalling the old app, your local historical data older than one week will be lost!**
 
-To finally get your data to AndroidAPS, you need to install [ESEL](https://github.com/BernhardRo/Esel/blob/master/apk/esel.apk) and enable "Send to AAPS and xDrip" in ESEL and "MM640g" as BG source in the [Configuration Builder](../Configuration/Config-Builder.md) in AndroidAPS. As the BG data from Eversense can be noisy sometimes, it is good to enable "Smooth Data" in ESEL, which is better than enabling "Always use short average delta instead of simple data".
+To finally get your data to AndroidAPS, you need to install [ESEL](https://github.com/BernhardRo/Esel/blob/master/apk/esel.apk) and enable "Send to AAPS and xDrip" in ESEL and "MM640g" as BG source in the [Configuration Builder](../Configuration/Config-Builder.md) in AndroidAPS. As the BG data from Eversense can be noisy sometimes, it is good to enable "Smooth Data" in ESEL, which is better than enabling "Always use short average delta instead of simple delta" in AAPS.
 
 You can find another instruction for using xDrip with an Eversense [here](https://github.com/BernhardRo/Esel/tree/master/apk).
 
 ## For users of MM640g or MM630g<br>
-* If not already set up then download [600SeriesAndroidUploaer](http://pazaan.github.io/600SeriesAndroidUploader/) and follow instructions on [nightscout](http://www.nightscout.info/wiki/welcome/nightscout-and-medtronic-640g).
+* If not already set up then download [600SeriesAndroidUploaer](http://pazaan.github.io/600SeriesAndroidUploader/) and follow instructions on [Nightscout](http://www.nightscout.info/wiki/welcome/nightscout-and-medtronic-640g).
 * In 600 Series Uploader go to Settings > Send to xdrip+ and select ON (tick).
 * Select MM640g in ConfigBuilder (setting in AndroidAPS).
 
@@ -58,7 +58,7 @@ You can find another instruction for using xDrip with an Eversense [here](https:
 * Install PocTech App
 * Select PocTech App in ConfigBuilder (setting in AndroidAPS).
 
-**For users of other CGM uploaded to nightscout:**<br>
+## For users of other CGM uploaded to Nightscout<br>
 If you have any other CGM set up that sends your data to [Nightscout](http://www.nightscout.info) then<br>
-* In AndroidAPS Preferences enter your nightscout website and API secret.
+* In AndroidAPS Preferences enter your Nightscout website and API secret.
 * Select NSClient in ConfigBuilder (setting in AndroidAPS).


### PR DESCRIPTION
- Changed the end of sentence  "simple data" > "simple delta in AAPS":
As the BG data from Eversense can be noisy sometimes, it is good to enable "Smooth Data" in ESEL, which is better than enabling "Always use short average delta instead of **simple delta" in AAPS**.
@mariet1d or another Eversense expert can you please check if this is meant here?

- Typos:
600SeriesAndroidUploaer > 600SeriesAndroidUploader
nightscout > Nightscout

- Aligned header size w rest of page:
For users of other CGM uploaded to nightscout

