### PR TITLE
Change in image description

### DIFF
--- a/docs/EN/Configuration/Preferences.md
+++ b/docs/EN/Configuration/Preferences.md
@@ -11,7 +11,7 @@ There are security limits in place based on age you selected in this setting. If
 * Quick Wizard settings allows you to add a quick button for a frequent snack or meal, enter your decided carb details and on the homescreen if you select the quick wizard button it will calculate and bolus for those carbs based on your current ratios (taking into account blood glucose value or insulin on board if set up).
 * Advanced settings to enable superbolus in wizard and to show status lights on home screen. Status lights give a visual warning for low reservoir and battery level as well as overdue site change.
 
-   ![Status lights](../../images/StatusLights.jpg)
+   ![Status lights - screen detail](../../images/StatusLights.jpg)
 
 ## Careportal
 'Entered by' is the text displayed in your nightscout careportal 'entered by' field.  Set this to something meaningful to you, whether it is the app name, the person's name or the phone name (for example if you are using AndroidAPS as NS Client on a phone that is not the patient's phone you may wish to distinguish between phone owners here).

--- a/docs/EN/Getting-Started/Screenshots.md
+++ b/docs/EN/Getting-Started/Screenshots.md
@@ -2,7 +2,7 @@
 
 ## The Homescreen
 
-![Homescreen](../../images/Screenshot_Home_screen_V2_1.png)
+![Homescreen v2.1](../../images/Screenshot_Home_screen_V2_1.png)
 
 This is the first screen you will come across when you open AndroidAPS and it contains most of the information that you will need day to day.
 


### PR DESCRIPTION
Small change to make new PR in order to have image of homescreen and status lights updated also in Crowdin translated versions.
Somehow l10n_master (https://androidaps.readthedocs.io/en/l10n_master/EN/Getting-Started/Screenshots.html) contains old image reference whereas actual wiki is up to date (https://androidaps.readthedocs.io/en/latest/EN/Getting-Started/Screenshots.html - English only, German shows no picture).