### PR TITLE
Change nighlty info

### DIFF
--- a/docs/EN/Configuration/xdrip.md
+++ b/docs/EN/Configuration/xdrip.md
@@ -4,7 +4,7 @@ If not already set up then download [xDrip+](https://github.com/NightscoutFounda
 
 For G6 transmitters manufactured after fall/end of 2018 please make sure to use one of the [latest nightly build xDrip+ versions](https://github.com/NightscoutFoundation/xDrip/releases). Those transmitters have a new firmware and latest stable version of xDrip+ (2019/01/10) cannot deal with it.
 
-**At the moment there are some problems with nightly builds after 2019/05/21 asking for G6 calibration.**
+**If your Dexcom transmitter's serial no. is starting with 8G... try nightly build 2019/07/28 or later.**
 
 
 ## Basic settings for all CGM & FGM systems


### PR DESCRIPTION
Newer nightlys after May seem to work with G6 w/o claibration problem. Therefore hint deleted.
Peter Leimbach reported that G6 8G... works with actual nightly build.