### PR TITLE
Move translation PNG

### DIFF
--- a/docs/EN/translations.md
+++ b/docs/EN/translations.md
@@ -5,18 +5,18 @@
 * Send a join request to the Wiki team. To do so click on the flag of the desired language and then the button "Join" on the top right corner of the next page. Please specify language, give some information about you and your AAPS experience and if you want to be a translator or proofreader (only people skilled in translating + advanced AndroidAPS users).
 
 * When we approve you, click the flag
-   ![When we approve you, click the flag](../images/translation-flags.png)
+   ![When we approve you, click the flag](./images/translation-flags.png)
 
-* Click strings.xml
-   ![Click strings.xml](../images/translations-click-strings.png)
+* Click strings.xml (when translating AAPS app) or the name of the wiki page
+   ![Click strings.xml](./images/translations-click-strings.png)
 
 * Translate sentences on left side by adding new translated text or use & edit suggestion 
-   ![Translation](../images/translations-translate.png)
+   ![Translation](./images/translations-translate.png)
 
 * Proofreaders have to switch to Proofreading mode 
-   ![Proffreading mode](../images/translations-proofreading-mode.png) 
+   ![Proffreading mode](./images/translations-proofreading-mode.png) 
 
   and approve translated texts 
-   ![approve text](../images/translations-proofreading.png)
+   ![approve text](./images/translations-proofreading.png)
 
 When a proofreader approves a translation it will be added to the next version of AndroidAPS. In the beginning it would be good to also go over the existing translations that are not yet approved and check for mistakes or approve them if they are correct.


### PR DESCRIPTION
in order to have them visible in translated pages - due to different URL
https://androidaps.readthedocs.io/en/latest/EN/translations.html
https://androidaps.readthedocs.io/en/latest/CROWDIN/de/translations.html (folder CROWDIN additionally in URL)