### PR TITLE
Update Children.rst

### DIFF
--- a/docs/EN/Children/Children.rst
+++ b/docs/EN/Children/Children.rst
@@ -4,27 +4,29 @@ Remote monitoring
 .. image:: ../images/KidsMonitoring.png
   :alt: Monitoring children
   
-AndroidAPS offer several options for remote monitoring of children and also allows to send remote commands. Of course you can also use remote monitoring to follow your partner or friend.
+There for severval different methods to remotely monitor AndroidAPS and/or  blood glucose levels of children, a partner or even a friend. The ability to send commands remotely, esp to children, is possible with AndroidAPS.
 
-Functions
+Methodology
 =========
-* Kid's pump is controlled by kid's phone using AndroidAPS.
-* Parents can remotely follow seeing all relevant data such as glucose levels, carbs on board, insulin on board etc. using **NSClient app** on their phone.
-* Parents can be alarmed by using **xDrip app in follower mode** on their phone.
-* Remote control of AndroidAPS using `SMS Commands <../Usage/SMS-Commands.html>`_.
-* Remote profile switch and temp targets through NSClient app.
+* A child's pump is locally controlled by AndroidAPS, that has been installed on the child's Android phone.
+* A parent/carer can remotely follow the child's AndroidAPS app using the **NSClient app** on their phone.
+* **NSClient app** allows the visulization of glucose levels, carbs on bard (COB), insulin on board (IOB), temporary targets, basal rates, etc of AdroidAPS, lacking only in the controlling of the pump.
+* Remote profile switch and temp targets can be done through **NSClient app**.
+* Remote control of AndroidAPS on the child's phone using `SMS Commands <../Usage/SMS-Commands.html>`_ is possible.
+* A parent/carer can be alarmed by using **xDrip app in follower mode** on their Android phone.
 
-Tools and apps for remote monitoring
+
+Other Tools and Apps for Partial Monitoring(other than NSClient app)
 ------------------------------------
 * `Nightscout <http://www.nightscout.info/>`_ in web browser (mainly data display)
-*	NSClient app
-*	Dexcom follow if you are using original Dexcom app (BG values only)
-*	`xDrip <../Configuration/xdrip.html>`_ in follower mode (mainly BG values and **alarms**)
+*	Dexcom Follow app if you are using the original Dexcom app on iPhone or Android (BG values and limited alarms)
+*	`xDrip <../Configuration/xdrip.html>`_ in follower mode on Android (mainly BG values and **alarms**) 
 *	`Spike <https://spike-app.com/>`_ on iPhone (mainly BG values and **alarms**)
+* Dexcom Follow app can also be used from xDrip+ (xDrip+, Settings, Cloud Upload, Dexcom Share Server Upload, check Upload BG values as Dexcom Share, enter login for Dexcom Account login, enter Dexcom Account Password). This option will allow a larger number of followers from Dexcom follow. However please consider XDrip+ in a follower mode for android or Spike on iPhone as alternatives.
 
 Things to consider
 ==================
-* Setting the correct `treatment factors <../Getting-Started/FAQ.html#how-to-begin>`_ (basal rate, DIA, ISF...) is difficult for kids, especially when growth hormones are involved. 
-* So take your time to set those correctly and test them in real life with your kid next to you before starting remote monitoring and remote treatment. School holidays might be a good time for that.
+* Setting the correct `treatment factors <../Getting-Started/FAQ.html#how-to-begin>`_ (basal rate, DIA, ISF...) is difficult for children, especially when growth hormones are involved. 
+* So take your time to set those correctly and test them in real life with your child next to you before starting remote monitoring and remote treatment. School holidays might be a good time for that.
 * What is your emergency plan when remote control does not work (i.e. network problems)?
 * Remote monitoring and treatment can be really helpful in kinder garden and elementary school. But make sure the teachers and educators are aware of your kid's treatment plan. Examples for such care plans can be found in the `files section of AndroidAPS users <https://www.facebook.com/groups/AndroidAPSUsers/files/>`_ on Facebook.


### PR DESCRIPTION
With the questions that are part of the future versions of AdroidAPS there is a bit of a confusion in the topic: monitoring children: how can you monitor AAPS of your child remotely? 
only NSClient can monitor AAPS; 
Xdrip+, Spike, Dexcom Follow are monitoring  BG's and giving  alarms but it would be wrong to regard them as remotely monitoring  AAPS.
So I have partially edited this page to introduce and explain NSClient app. 
I have also explained the other apps as tools to monitor BG and not AAPS ( since they do not monitor AAPS)
I have also include that Dexcom Follow can also be used from xDrip+ as well as from  the app Dexcom but with a note that there are other preferred options. 
Please consider the new headings:  methodology;  other tools and apps for partial monitoring 
Lastly the answers of the objective would need to be changed to only NSClient being correct, o rthe question rephrased to something like : "What tools are available to assist in the remote monitor of your child using AAPS?" and the answer would be all but "Loop app on iPhone ".