### PR TITLE
Update status and URL of native Java Omnipod driver for AAPS

### DIFF
--- a/docs/EN/Getting-Started/Future-possible-Pump-Drivers.md
+++ b/docs/EN/Getting-Started/Future-possible-Pump-Drivers.md
@@ -23,7 +23,7 @@ AAPS. 0.10 test "release" is out, with about 95% of all functionality, at the mo
 ***
 
 
-### Insulet Omnipod (with old Eros Pods) ([Homepage](https://www.myomnipod.com/en-gb/about/how-to-use))
+### Insulet Omnipod (with "old" Eros Pods) ([Homepage](https://www.myomnipod.com/en-gb/about/how-to-use))
 
 **Loop status:** Not supported natively by AAPS at the moment. Decoding of the Omnipod protocol is finished- [OpenOmni](http://www.openomni.org/) and [OmniAPS Slack](https://omniaps.slack.com/)
 
@@ -34,7 +34,7 @@ AAPS. 0.10 test "release" is out, with about 95% of all functionality, at the mo
 
 **Java implementations:**  None till now.
 
-**AAPS implementation status:** Work has started on [RileyLinkAAPS](https://github.com/bartsopers/RileyLinkAAPS/) for Omnipod (dev_omnipod branch) which will not require a Raspberry Pi, but this is not finished. You can follow progress on https://omniaps.slack.com/ channel android-driver.
+**AAPS implementation status:** Work on a native Java driver for Omnipod on AAPS is progressing on [AAPS-Omnipod/AndroidAPS](https://github.com/AAPS-Omnipod/AndroidAPS) (omnipod_eros branch). It does not require a Raspberry Pi. You can follow progress on [the OmniAPS Slack](https://omniaps.slack.com/) on channel android-driver. A first public test version is expected to be released around January 2020.
 
 **Hardware requirement for AAPS:** RileyLink with Omnipod firmware (2.x) and 433 MHz antenna.
 


### PR DESCRIPTION
I think the status for Medtronic on this page is also outdated, but I'm not familiar enough with that to change it.