### PR TITLE
Update xdrip.md with instruction to pair device

### DIFF
--- a/docs/EN/Configuration/xdrip.md
+++ b/docs/EN/Configuration/xdrip.md
@@ -114,16 +114,17 @@ If your Dexcom G6 transmitter's serial no. is starting with 8G, 8H or 8J try [ni
 * Use the Source Wizard Button which ensures default settings including OB1 & Native Mode
    - This guides you through the initial set up.
    - you will need your transmitter serial number if this is the first time you've used it.
-* Put in serial number of new transmitter (on the transmitter packaging or on the back of the transmitter). Be careful not to confuse 0 (zero) and O (capital letter o).
+* Put in serial number of new transmitter (on the transmitter packaging or on the back of the transmitter). Be careful not to confuse `0` (zero) and `O` (capital letter o).
 
    ![xDrip+ Dexcom Transmitter Serial No](../images/xDrip_Dexcom_TransmitterSN.png)
 
 * Insert new sensor (only if replacing)
 * Put transmitter into sensor
+* If a message pops up asking to pair with "DexcomXX", where "XX" is the last two characters of the transmitter, accept it (tap "pair")
 * Do not start new sensor before the following information is shown in Classic Status Page -> G5/G6 status -> PhoneServiceState:
 
   * Transmitter serial starting with 80 or 81: "Got data hh:mm" (i.e. "Got data 19:04")
-  * Transmitter serial starting with 8G, 8H or 8J: "Got glucose hh:mm" (i.e. "Got glucose 19:04") or "Got no raw hh:mm" (i.e. "Got now raw 19:04")
+  * Transmitter serial starting with 8G, 8H or 8J: "Got glucose hh:mm" (i.e. "Got glucose 19:04") or "Got no raw hh:mm" (i.e. "Got no raw 19:04")
 
    ![xDrip+ PhoneServiceState](../images/xDrip_Dexcom_PhoneServiceState.png)
 


### PR DESCRIPTION
I ran into an issue following the documentation to set up xDrip+ where I didn't realize that I needed to accept the pairing request on my phone (Pixel 5 running Android 11) for it to work. I think that this may have also happened on my last phone (Pixel 2 XL) as well, but it was several years since I've switched phones.

![Screenshot_20201204-064627](https://user-images.githubusercontent.com/1148665/101172114-f9455280-35fd-11eb-895c-d135d83c9a82.png)

Thinking it was a BLE connection that didn't need pairing, I hit "cancel". After waiting for it to come back and realizing that I needed to hit "pair", the phone paired fine with the transmitter, but this PR adds a note to accept the dialog that comes up, to help others avoid my mistake and get started faster.

Would you like the image above to also be included (probably cropped and resized)?

Also fixes a small typo and adds a little formatting to better differentiate `0` and `O` in the text.