### PR TITLE
Fix various build warnings

### DIFF
--- a/docs/EN/Children/SMS-Commands.rst
+++ b/docs/EN/Children/SMS-Commands.rst
@@ -43,26 +43,26 @@ Additionally mandatory PIN at token end
 * For safety reasons the reply code must be followed by a PIN.
 * PIN rules:
 
-   * 3 to 6 digits
-   * not same digits (i.e. 1111)
-   * not in a row (i.e. 1234)
+  * 3 to 6 digits
+  * not same digits (i.e. 1111)
+  * not in a row (i.e. 1234)
 
 Authenticator setup
 -------------------------------------------------
 * Two-factor authentication is used to improve safety.
 * You can use any Authenticator app that supports RFC 6238 TOTP tokens. Popular free apps are:
 
-   * `Authy <https://authy.com/download/>`_
-   * Google Authenticator - `Android <https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2>`_ / `iOS <https://apps.apple.com/de/app/google-authenticator/id388497605>`_
-   * `LastPass Authenticator <https://lastpass.com/auth/>`_
-   * `FreeOTP Authenticator <https://freeotp.github.io/>`_
+  * `Authy <https://authy.com/download/>`_
+  * Google Authenticator - `Android <https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2>`_ / `iOS <https://apps.apple.com/de/app/google-authenticator/id388497605>`_
+  * `LastPass Authenticator <https://lastpass.com/auth/>`_
+  * `FreeOTP Authenticator <https://freeotp.github.io/>`_
 
 * Install the authenticator app of your choice on your follower phone and scan the QR code shown in AAPS.
 * Test the one-time password by entering the token shown in your authenticator app and the PIN you just setup in AAPS. Example:
 
-   * Your mandatory PIN is 2020
-   * TOTP token from the authenticator app is 457051
-   * Enter 4570512020
+  * Your mandatory PIN is 2020
+  * TOTP token from the authenticator app is 457051
+  * Enter 4570512020
    
 * The red text "WRONG PIN" will change **automatically** to a green "OK" if the entry is correct. **There is no button you can press!**
 * The time on both phones must be synchronized. Best practice is set automatically from network. Time differences might lead to authentication problems.
@@ -74,9 +74,9 @@ Use SMS commands
 * The AAPS phone will respond to confirm success of command or status requested. 
 * Confirm command by sending the code where necessary. Example:
 
-   * Your mandatory PIN is 2020
-   * TOTP token from the authenticator app is 457051
-   * Enter 4570512020
+  * Your mandatory PIN is 2020
+  * TOTP token from the authenticator app is 457051
+  * Enter 4570512020
 
 **Hint**: It can be useful to have unlimited SMS on your phone plan (for each phone used) if a lot of SMS will be sent.
 
@@ -90,93 +90,95 @@ Commands must be sent in English, the response will be in your local language if
 Loop
 --------------------------------------------------
 * LOOP STOP/DISABLE
-   * Response: Loop has been disabled
+  * Response: Loop has been disabled
 * LOOP START/ENABLE
-   * Response: Loop has been enabled
+  * Response: Loop has been enabled
 * LOOP STATUS
-   * Response depends on actual status
-      * Loop is disabled
-      * Loop is enabled
-      * Suspended (10 min)
+
+  * Response depends on actual status
+
+    * Loop is disabled
+    * Loop is enabled
+    * Suspended (10 min)
 * LOOP SUSPEND 20
-   * Response: Loop suspended for 20 minutes
+  * Response: Loop suspended for 20 minutes
 * LOOP RESUME
-   * Response: Loop resumed
+  * Response: Loop resumed
 
 CGM data
 --------------------------------------------------
 * BG
-   * Response: Last BG: 5.6 4min ago, Delta: -0,2 mmol, IOB: 0.20U (Bolus: 0.10U Basal: 0.10U)
+  * Response: Last BG: 5.6 4min ago, Delta: -0,2 mmol, IOB: 0.20U (Bolus: 0.10U Basal: 0.10U)
 * CAL 5.6
-   * Response: To send calibration 5.6 reply with code from Authenticator app for User followed by PIN
-   * Response after correct code was received: Calibration sent (**If xDrip is installed. Accepting calibrations must be enabled in xDrip+**)
+  * Response: To send calibration 5.6 reply with code from Authenticator app for User followed by PIN
+  * Response after correct code was received: Calibration sent (**If xDrip is installed. Accepting calibrations must be enabled in xDrip+**)
 
 Basal
 --------------------------------------------------
 * BASAL STOP/CANCEL
-   * Response: To stop temp basal reply with code from Authenticator app for User followed by PIN
+  * Response: To stop temp basal reply with code from Authenticator app for User followed by PIN
 * BASAL 0.3
-   * Response: To start basal 0.3U/h for 30 min reply with code from Authenticator app for User followed by PIN
+  * Response: To start basal 0.3U/h for 30 min reply with code from Authenticator app for User followed by PIN
 * BASAL 0.3 20
-   * Response: To start basal 0.3U/h for 20 min reply with code from Authenticator app for User followed by PIN
+  * Response: To start basal 0.3U/h for 20 min reply with code from Authenticator app for User followed by PIN
 * BASAL 30%
-   * Response: To start basal 30% for 30 min reply with code from Authenticator app for User followed by PIN
+  * Response: To start basal 30% for 30 min reply with code from Authenticator app for User followed by PIN
 * BASAL 30% 50
-   * Response: To start basal 30% for 50 min reply with code from Authenticator app for User followed by PIN
+  * Response: To start basal 30% for 50 min reply with code from Authenticator app for User followed by PIN
 
 Bolus
 --------------------------------------------------
 Remote bolus is not allowed within 15 min (this value is editable only if 2 phone numbers added) after last bolus command or remote commands! Therefore the response depends on the time that the last bolus was given.
 
 * BOLUS 1.2
-   * Response A: To deliver bolus 1.2U reply with code from Authenticator app for User followed by PIN
-   * Response B: Remote bolus not available. Try again later.
+  * Response A: To deliver bolus 1.2U reply with code from Authenticator app for User followed by PIN
+  * Response B: Remote bolus not available. Try again later.
 * BOLUS 0.60 MEAL
-   * If you specify the optional parameter MEAL, this sets the Temp Target MEAL (default values are: 90 mg/dL, 5.0 mmol/l for 45 mins).
-   * Response A: To deliver meal bolus 0.60U reply with code from Authenticator app for User followed by PIN
-   * Response B: Remote bolus not available. 
+  * If you specify the optional parameter MEAL, this sets the Temp Target MEAL (default values are: 90 mg/dL, 5.0 mmol/l for 45 mins).
+  * Response A: To deliver meal bolus 0.60U reply with code from Authenticator app for User followed by PIN
+  * Response B: Remote bolus not available. 
 * CARBS 5
-   * Response: To enter 5g at 12:45 reply with code from Authenticator app for User followed by PIN
+  * Response: To enter 5g at 12:45 reply with code from Authenticator app for User followed by PIN
 * CARBS 5 17:35/5:35PM
-   * Response: To enter 5g at 17:35 reply with code from Authenticator app for User followed by PIN
+  * Response: To enter 5g at 17:35 reply with code from Authenticator app for User followed by PIN
 * EXTENDED STOP/CANCEL
-   * Response: To stop extended bolus reply with code from Authenticator app for User followed by PIN
+  * Response: To stop extended bolus reply with code from Authenticator app for User followed by PIN
 * EXTENDED 2 120
-   * Response: To start extended bolus 2U for 120 min reply with code from Authenticator app for User followed by PIN
+  * Response: To start extended bolus 2U for 120 min reply with code from Authenticator app for User followed by PIN
 
 Profile
 --------------------------------------------------
 * PROFILE STATUS
-   * Response: Profile1
+  * Response: Profile1
 * PROFILE LIST
-   * Response: 1.`Profile1` 2.`Profile2`
+  * Response: 1.`Profile1` 2.`Profile2`
 * PROFILE 1
-   * Response: To switch profile to Profile1 100% reply with code from Authenticator app for User followed by PIN
+  * Response: To switch profile to Profile1 100% reply with code from Authenticator app for User followed by PIN
 * PROFILE 2 30
-   * Response: To switch profile to Profile2 30% reply with code from Authenticator app for User followed by PIN
+  * Response: To switch profile to Profile2 30% reply with code from Authenticator app for User followed by PIN
 
 Other
 --------------------------------------------------
 * TREATMENTS REFRESH
-   * Response: Refresh treatments from NS
+  * Response: Refresh treatments from NS
 * NSCLIENT RESTART
-   * Response: NSCLIENT RESTART 1 receivers
+  * Response: NSCLIENT RESTART 1 receivers
 * PUMP
-   * Response: Last conn: 1 min ago Temp: 0.00U/h @11:38 5/30min IOB: 0.5U Reserv: 34U Batt: 100
+  * Response: Last conn: 1 min ago Temp: 0.00U/h @11:38 5/30min IOB: 0.5U Reserv: 34U Batt: 100
 * PUMP CONNECT
-   * Response: Pump reconnected
+  * Response: Pump reconnected
 * PUMP DISCONNECT *30*
-   * Response: To disconnect pump for *30* minutes reply with code from Authenticator app for User followed by PIN
+  * Response: To disconnect pump for *30* minutes reply with code from Authenticator app for User followed by PIN
 * SMS DISABLE/STOP
-   * Response: To disable the SMS Remote Service reply with code Any. Keep in mind that you'll able to reactivate it directly from the AAPS master smartphone only.
+  * Response: To disable the SMS Remote Service reply with code Any. Keep in mind that you'll able to reactivate it directly from the AAPS master smartphone only.
 * TARGET MEAL/ACTIVITY/HYPO   
-   * Response: To set the Temp Target MEAL/ACTIVITY/HYPO reply with code from Authenticator app for User followed by PIN
+  * Response: To set the Temp Target MEAL/ACTIVITY/HYPO reply with code from Authenticator app for User followed by PIN
 * TARGET STOP/CANCEL   
-   * Response: To cancel Temp Target reply with code from Authenticator app for User followed by PIN
+  * Response: To cancel Temp Target reply with code from Authenticator app for User followed by PIN
 * HELP
-   * Response: BG, LOOP, TREATMENTS, .....
+  * Response: BG, LOOP, TREATMENTS, .....
 * HELP BOLUS
-   * Response: BOLUS 1.2 BOLUS 1.2 MEAL
+  * Response: BOLUS 1.2 BOLUS 1.2 MEAL
 
 Troubleshooting
 ==================================================

--- a/docs/EN/Configuration/BG-Source.rst
+++ b/docs/EN/Configuration/BG-Source.rst
@@ -17,5 +17,4 @@ BG Source
    Eversense <../Hardware/Eversense.rst>
    MM640g/MM630g  <../Hardware/MM640g.rst>
    PocTech <../Hardware/PocTech.rst>   
-   Nightscout as BG Source <../Hardware/CGMNightscoutUpload.rst>
-   
+   Nightscout as BG Source <../Hardware/CgmNightscoutUpload.rst>

--- a/docs/EN/Configuration/Config-Builder.md
+++ b/docs/EN/Configuration/Config-Builder.md
@@ -167,9 +167,9 @@ If you use Oref1 with SMB you must change <b>min_5m_carbimpact</b> to 8. The val
 
 ## APS
 Select the desired APS algorithm for therapy adjustments. You can view the active detail of the chosen algorithm in the OpenAPS(OAPS) tab.
-- OpenAPS AMA (advanced meal assist, state of the algorithm in 2017)  
-More detail about OpenAPS AMA can be found in the [OpenAPS docs](http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autosens.html#advanced-meal-assist-or-ama). In simple terms the benefits are after you give yourself a meal bolus the system can high-temp more quickly IF you enter carbs reliably.  
-- [OpenAPS SMB](../Usage/Open-APS-features.md) (super micro bolus, most recent algorithm for advanced users)  
+- OpenAPS AMA (advanced meal assist, state of the algorithm in 2017)
+More detail about OpenAPS AMA can be found in the [OpenAPS docs](http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autosens.html#advanced-meal-assist-or-ama). In simple terms the benefits are after you give yourself a meal bolus the system can high-temp more quickly IF you enter carbs reliably.
+- [OpenAPS SMB](../Usage/Open-APS-features.md) (super micro bolus, most recent algorithm for advanced users)
 Note you need to be in [Objective 10](../Usage/Objectives#objective-10-enabling-additional-oref1-features-for-daytime-use-such-as-super-micro-bolus-smb) in order to use OpenAPS SMB and min_5m_carbimpact must be set to 8 in Config builder > Sensitivity detection > Sensitivity Oref1 settings.
 
 ## Loop

--- a/docs/EN/Configuration/OmnipodEros.rst
+++ b/docs/EN/Configuration/OmnipodEros.rst
@@ -26,7 +26,7 @@ Hardware and Software Requirements
 
   Component that will operate AndroidAPS and send control commands to the Pod communication device.
 
-      +  Supported `Omnipod driver Android phone <https://docs.google.com/spreadsheets/d/1eNtXAWwrdVtDvsvXaR_72wgT9ICjZPNEBq8DbitCv_4/edit#gid=0>`__ with a version of AAPS 2.8 and related `components setup <https://androidaps.readthedocs.io/en/latest/EN/index.html#component-setup>`__
+      +  Supported `Omnipod driver Android phone <https://docs.google.com/spreadsheets/d/1eNtXAWwrdVtDvsvXaR_72wgT9ICjZPNEBq8DbitCv_4/edit#gid=0>`__ with a version of AAPS 2.8 and related `components setup <../index.html#component-setup>`__
 
 *  |Omnipod_Pod|  **Insulin Delivery Device** 
 

--- a/docs/EN/Configuration/OmnipodEros.rst
+++ b/docs/EN/Configuration/OmnipodEros.rst
@@ -132,7 +132,7 @@ Activating a Pod
 
 Before you can activate a pod please ensure you have properly configured and connected your RileyLink connection in the Omnipod settings
 
-*REMINDER: Pod communication occurs at limited ranges for pod activation pairing due to security safety measures. Before pairing the Pod's radio signal is weaker, however after it has been paired it will operate at full signal power. During these procedures, make sure that your pod is* `within close proximity <#optimal-omnipod-and-rileylink-positioning>`__ *(~30 cm away or less) but not on top of or right next to the RileyLink.  
+*REMINDER: Pod communication occurs at limited ranges for pod activation pairing due to security safety measures. Before pairing the Pod's radio signal is weaker, however after it has been paired it will operate at full signal power. During these procedures, make sure that your pod is* `within close proximity <#optimal-omnipod-and-rileylink-positioning>`__ *(~30 cm away or less) but not on top of or right next to the RileyLink.*
 
 1. Navigate to the **Omnipod (POD)** tab and click on the **POD MGMT (1)** button, and then click on **Activate Pod (2)**.
 
@@ -749,7 +749,7 @@ Pod suspended
 Informational alert that Pod has been suspended.
 
 Setting basal profile failed. Delivery might be suspended! Please manually refresh the Pod status from the Omnipod tab and resume delivery if needed..
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Informational alert that the Pod basal profile setting has failed, and you will need to hit *Refresh* on the Omnipod tab.
 

--- a/docs/EN/Configuration/Preferences.rst
+++ b/docs/EN/Configuration/Preferences.rst
@@ -46,8 +46,7 @@ Protection
 Master password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Necessary to be able to `export settings <../Usage/ExportImportSettings.html>`_ as they are encrypted as of version 2.7.
-
-   **Biometric protection does not work on OnePlus phones. This is a know issue of OnePlus.**
+  **Biometric protection does not work on OnePlus phones. This is a know issue of OnePlus.**
 
 * Open Preferences (three-dot-menu on top right of home screen)
 * Click triangle below "General"
@@ -172,14 +171,14 @@ Show notes field in treatments dialogs
 Status lights
 -----------------------------------------------------------
 * Status lights give a visual warning for 
-      
-   * Sensor age
-   * Sensor battery level for certain smart readers (see `screenshots page <../Getting-Started/Screenshots.html#sensor-level-battery>`_ for details).
-   * Insulin age (days reservoir is used)
-   * Reservoir level (units)
-   * Cannula age
-   * Pump battery age
-   * Pump battery level (%)
+
+  * Sensor age
+  * Sensor battery level for certain smart readers (see `screenshots page <../Getting-Started/Screenshots.html#sensor-level-battery>`_ for details).
+  * Insulin age (days reservoir is used)
+  * Reservoir level (units)
+  * Cannula age
+  * Pump battery age
+  * Pump battery level (%)
 
 * If threshold warning is exceeded, values will be shown in yellow.
 * If threshold critical is exceeded, values will be shown in red.
@@ -191,8 +190,8 @@ Status lights
 Advanced Settings (Overview)
 -----------------------------------------------------------
 
-  .. image:: ../images/Pref2021_OV_Adv.png
-    :alt: Preferences > Status Lights
+.. image:: ../images/Pref2021_OV_Adv.png
+  :alt: Preferences > Status Lights
 
 Deliver this part of bolus wizard result
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -336,8 +335,8 @@ Advanced settings (OpenAPS SMB)
 Absorption settings
 ===========================================================
 
-  .. image:: ../images/Pref2020_Absorption.png
-    :alt: Absorption settings
+.. image:: ../images/Pref2020_Absorption.png
+  :alt: Absorption settings
 
 min_5m_carbimpact
 -----------------------------------------------------------
@@ -377,8 +376,8 @@ If using AndroidAPS to open loop then make sure you have selected Virtual Pump i
 NSClient
 ===========================================================
 
-  .. image:: ../images/Pref2020_NSClient.png
-    :alt: NSClient
+.. image:: ../images/Pref2020_NSClient.png
+  :alt: NSClient
 
 * Set your *Nightscout URL* (i.e. https://yourwebsitename.herokuapp.com) and the *API secret* (a 12 character password recorded in your Heroku variables).
 * This enables data to be read and written between both the Nightscout website and AndroidAPS.  
@@ -390,8 +389,8 @@ NSClient
 Connection settings
 -----------------------------------------------------------
 
-  .. image:: ../images/ConfBuild_ConnectionSettings.png
-    :alt: NSClient connection settings  
+.. image:: ../images/ConfBuild_ConnectionSettings.png
+  :alt: NSClient connection settings
   
 * Restrict Nightscout upload to Wi-Fi only or even to certain Wi-Fi SSIDs.
 * If you want to use only a specific WiFi network you can enter its WiFi SSID. 
@@ -408,8 +407,8 @@ Alarm options
 Advanced settings (NSClient)
 -----------------------------------------------------------
 
-  .. image:: ../images/Pref2020_NSClientAdv.png
-    :alt: NS Client advanced settings
+.. image:: ../images/Pref2020_NSClientAdv.png
+  :alt: NS Client advanced settings
 
 * Most options in advanced settings are self-explanatory.
 * *Enable local broadcasts* will share your data to other apps on the phone such as xDrip+. 
@@ -437,24 +436,24 @@ Select which location service shall be used:
 Local alerts
 ===========================================================
 
-  .. image:: ../images/Pref2020_LocalAlerts.png
-    :alt: Local alerts
+.. image:: ../images/Pref2020_LocalAlerts.png
+  :alt: Local alerts
 
 * Settings should be self-explanatory.
 
 Data choices
 ===========================================================
 
-  .. image:: ../images/Pref2020_DataChoice.png
-    :alt: Data choices
+.. image:: ../images/Pref2020_DataChoice.png
+  :alt: Data choices
 
 * You can help develop AAPS further by sending crash reports to the developers.
 
 Maintenance settings
 ===========================================================
 
-  .. image:: ../images/Pref2020_Maintenance.png
-    :alt: Maintenance settings
+.. image:: ../images/Pref2020_Maintenance.png
+  :alt: Maintenance settings
 
 * Standard recipient of logs is logs@androidaps.org.
 * If you select *Encrypt exported settings* these are encrypted with your `master password <../Configuration/Preferences.html#master-password>`_. In this case master password has to be entered each time settings are exported or imported.
@@ -464,5 +463,5 @@ Open Humans
 * You can help the community by donating your data to research projects! Details are described on the `Open Humans page <../Configuration/OpenHumans.html>`_.
 * In Preferences you can define when data shall be uploaded
 
-   * only if connected to WiFi
-   * only if charging
+  * only if connected to WiFi
+  * only if charging

--- a/docs/EN/Getting-Started/ClosedLoop.rst
+++ b/docs/EN/Getting-Started/ClosedLoop.rst
@@ -23,7 +23,7 @@ Just as the autopilot depends on the sensor values as well as the pilot's specif
 
 
 Open Source Artificial Pancreas Closed Loop Systems
-==================================================
+===================================================
 At present there are three major open source closed loop systems available:
 
 AndroidAPS (AAPS)

--- a/docs/EN/Getting-Started/Screenshots.md
+++ b/docs/EN/Getting-Started/Screenshots.md
@@ -218,7 +218,7 @@ Usually your real glucose curve ends up in the middle of these lines, or close t
 
 ![Insulin button](../images/Home2020_ButtonInsulin.png)
 
-* To give a certain amount of insulin without using [bolus calculator](../Getting-Started/Screenhots#bolus-wizard).
+* To give a certain amount of insulin without using [bolus calculator](../Getting-Started/Screenshots#bolus-wizard).
 * By checking the box you can automatically start your [eating soon temp target](../Configuration/Preferences#default-temp-targets).
 * If you do not want to bolus through pump but record insulin amount (i.e. insulin given by syringe) check the corresponding box.
 

--- a/docs/EN/Getting-Started/WikiUpdate.rst
+++ b/docs/EN/Getting-Started/WikiUpdate.rst
@@ -8,11 +8,13 @@ January 2021
 * Libre smart reader `battery level <../Getting-Started/Screenshots.html#sensor-level-battery>`_
 * `Objectives <../Usage/Objectives.html#objective-3-prove-your-knowledge>`_ - new questions
 * Other `new AndroidAPS 2.8.0 functions <../Installing-AndroidAPS/Releasenotes.html#version-2-8-0>`_
+
 December 2020
 ==================================================
 * `Libre 2 <../Hardware/Libre2.html>`_ - patched app does not work with US sensors
 * `OpenAPS hard-coded limits <../Usage/Open-APS-features.html#overview-of-hard-coded-limits>`_
 * Sony Smartwatch 3 `Manual Installation of Google Play Service <../Usage/SonySW3.html>`_
+
 October 2020
 ==================================================
 * Accu-Chek Combo - update `time adjustment daylight savings time <../Usage/Timezone-traveling.html#time-adjustment-daylight-savings-time-dst>`_
@@ -20,14 +22,17 @@ October 2020
 * Logs - more details about `folder location <../Usage/Accessing-logfiles.html>`_
 * Omnipod Eros - `status update <../Getting-Started/Future-possible-Pump-Drivers.html#pumps-that-are-loopable>`_
 * `SMS commands - time sync <../Children/SMS-Commands.html>`_
+
 September 2020
 ==================================================
 * Major update for new AAPS version 2.7
 * For details see `release notes <../Installing-AndroidAPS/Releasenotes.html#version-2-7-0>`
+
 June 2020
 ==================================================
 * `Libre 2 <../Hardware/Libre2.html>`_ - more details patched Libre Link app & use of bluetooth transmitters
 * `Time zone travelling <../Usage/Timezone-traveling.html>`_ with Libre 2
+
 May 2020
 ==================================================
 * `Extended bolus only for Dana + Insight pumps <../Usage/Extended-Carbs.html#extended-bolus-and-switch-to-open-loop-dana-and-insight-pump-only>`_
@@ -35,16 +40,19 @@ May 2020
 * `Minimal request rate <../Configuration/Preferences.html#minimal-request-change>`_ to reduce number of notifications in open loop mode
 * `Patched Libre Link app <../Hardware/Libre2.html#step-1-build-your-own-patched-librelink-app>`_ - check if correctly patched
 * `Prediction lines <../Getting-Started/Screenshots.html#prediction-lines>`_ - more details
+
 April 2020
 ==================================================
 * `Backdate insulin <../Usage/CPbefore26.html#carbs--bolus>`_ (i.e. given by syringe)
 * `Android 6 support will be discontinued in next master version <../Module/module.html#phone>`_
+
 March 2020
 ==================================================
 * `Build apk with Android Studio 3.6.1 <../Installing-AndroidAPS/Building-APK.html>`_
 * `DanaRS with firmware v3 <../Configuration/DanaRS-Insulin-Pump.html>`_ **cannot currently be used with AndroidAPS!**
 * `Extended bolus and switch to open loop <../Usage/Extended-Carbs.html#extended-bolus-and-switch-to-open-loop-dana-and-insight-pump-only>`_
 * `Update apk with Android Studio 3.6.1 <../Installing-AndroidAPS/Update-to-new-version.html>`_
+
 February 2020
 ==================================================
 * `Automation caveats <../Usage/Automation.html#good-practice-caveats>`_
@@ -55,10 +63,12 @@ February 2020
 * `Sample Setup <../Getting-Started/Sample-Setup.html>`_ - update Dexcom G6
 * `Version 2.6.0 <../Installing-AndroidAPS/Releasenotes.html#version-2-6-0>`_ - major new features
 * `Wear complications <../Configuration/Watchfaces.html>`_
+
 January 2020
 ==================================================
 * `Manual carb correction <../Getting-Started/Screenshots.html#carb-correction>`_ for faulty carb entries
 * `Image size <../make-a-PR.html#image-size>`_ when editing docs
+
 December 2019
 ==================================================
 * `Android auto <../Usage/Android-auto.html>`_ - setup with screenshots
@@ -66,6 +76,7 @@ December 2019
 * `Glimp <../Configuration/Config-Builder.html#bg-source>`_ - version 4.15.57 and newer supported
 * `Watchfaces <../Configuration/Watchfaces.html>`_ - major update, way more details
 * `Watchface complications <../Configuration/Watchfaces.html#complications>`_ - use your favorite watchface with AAPS data
+
 November 2019
 ==================================================
 * `Automation - deactivate when disabling loop <../Usage/Automation.html#important-note>`_

--- a/docs/EN/Hardware/DexcomG5.rst
+++ b/docs/EN/Hardware/DexcomG5.rst
@@ -13,9 +13,9 @@ If using G5 with patched Dexcom app
 ==================================================
 * Download the apk from `https://github.com/dexcomapp/dexcomapp <https://github.com/dexcomapp/dexcomapp>`_, and choose the version that fits your needs (mg/dl or mmol/l version, G5).
 
-   * Folder 2.3 is for users of AndroidAPS 2.3, folder 2.4 for users of AAPS 2.5.
-   * Open https://play.google.com/store/search?q=dexcom%20g5 on your computer. Region will be visible in URL.
-   
+  * Folder 2.3 is for users of AndroidAPS 2.3, folder 2.4 for users of AAPS 2.5.
+  * Open https://play.google.com/store/search?q=dexcom%20g5 on your computer. Region will be visible in URL.
+
    .. image:: ../images/DexcomG5regionURL.PNG
      :alt: Region in Dexcom G5 URL
 

--- a/docs/EN/Hardware/DexcomG6.rst
+++ b/docs/EN/Hardware/DexcomG6.rst
@@ -33,11 +33,11 @@ If using G6 with patched Dexcom app
 ==================================================
 * Download the apk from `https://github.com/dexcomapp/dexcomapp <https://github.com/dexcomapp/dexcomapp>`_, and choose the version that fits your needs (mg/dl or mmol/l version, G6).
 
-   * Folder 2.4 for users of the current version, folder 2.3 is only for the outdated AndroidAPS 2.3.
-   * Open https://play.google.com/store/search?q=dexcom%20g6 on your computer. 
-   * Click the link to the Dexcom G6 app on the search results page that is displayed.
-   * Region will be visible in URL.
-   
+  * Folder 2.4 for users of the current version, folder 2.3 is only for the outdated AndroidAPS 2.3.
+  * Open https://play.google.com/store/search?q=dexcom%20g6 on your computer. 
+  * Click the link to the Dexcom G6 app on the search results page that is displayed.
+  * Region will be visible in URL.
+
    .. image:: ../images/DexcomG6regionURL.PNG
      :alt: Region in Dexcom G6 URL
 

--- a/docs/EN/Hardware/Libre2.rst
+++ b/docs/EN/Hardware/Libre2.rst
@@ -99,7 +99,7 @@ The blood sugar values are received on the smartphone by the xDrip+ App.
 * If necessary, enter "BgReading:d,xdrip libre_receiver:v" under Less Common Settings->Extra Logging Settings->Extra tags for logging. This will log additional error messages for trouble shooting.
 * In xDrip+ go to Settings > Interapp Compatibility > Broadcast Data Locally and select ON.
 * In xDrip+ go to Settings > Interapp Compatibility > Accept Treatments and select OFF.
-* to enable AAPS to receive blood sugar levels (version 2.5.x and later) from xDrip+ please set `Settings > Interapp Settings > Identify Receiver "info.nightscout.androidaps" <https://androidaps.readthedocs.io/en/latest/EN/Configuration/xdrip.html#identify-receiver>`_
+* to enable AAPS to receive blood sugar levels (version 2.5.x and later) from xDrip+ please set `Settings > Interapp Settings > Identify Receiver "info.nightscout.androidaps" <../Configuration/xdrip.html#identify-receiver>`_
 * If you want to be able to use AndroidAPS to calibrate then in xDrip+ go to Settings > Interapp Compatibility > Accept Calibrations and select ON.  You may also want to review the options in Settings > Less Common Settings > Advanced Calibration Settings.
 
 .. image:: ../images/Libre2_Tags.png

--- a/docs/EN/Installing-AndroidAPS/Releasenotes.rst
+++ b/docs/EN/Installing-AndroidAPS/Releasenotes.rst
@@ -123,7 +123,7 @@ Release date: 03-05-2020
 Please use `Android Studio 3.6.1 <https://developer.android.com/studio/>`_ or newer to build the apk.
 
 Major new features
------
+------------------
 * Insight: Disable vibration on bolus for firmware version 3
 * Otherwise is equal to 2.6.1.2. Update is optional. 
 
@@ -134,7 +134,7 @@ Release date: 19-04-2020
 Please use `Android Studio 3.6.1 <https://developer.android.com/studio/>`_ or newer to build the apk.
 
 Major new features
------
+------------------
 * Fix crashing in Insight service
 * Otherwise is equal to 2.6.1.1. If you are not affected by this bug you don't need to upgrade.
 
@@ -145,7 +145,7 @@ Release date: 06-04-2020
 Please use `Android Studio 3.6.1 <https://developer.android.com/studio/>`_ or newer to build the apk.
 
 Major new features
------
+------------------
 * Resolves SMS CARBS command issue while using Combo pump
 * Otherwise is equal to 2.6.1. If you are not affected by this bug you don't need to upgrade.
 
@@ -156,7 +156,7 @@ Release date: 21-03-2020
 Please use `Android Studio 3.6.1 <https://developer.android.com/studio/>`_ or newer to build the apk.
 
 Major new features
------
+------------------
 * Allow to enter only https:// in NSClient settings
 * Fixed `BGI <../Getting-Started/Glossary.html>`_ displaying bug on watches
 * Fixed small UI bugs
@@ -175,7 +175,7 @@ Release date: 29-02-2020
 Please use `Android Studio 3.6.1 <https://developer.android.com/studio/>`_ or newer to build the apk.
 
 Major new features
------
+------------------
 * Small design changes (startpage...)
 * Careportal tab / menu removed - more details `here <../Usage/CPbefore26.html>`_
 * New `Local Profile plugin <../Configuration/Config-Builder.html#local-profile-recommended>`_
@@ -328,10 +328,10 @@ Settings to adjust when switching from AMA to SMB
 * min_5m_carbimpact default has changed from 3 to 8 going from AMA to SMB. If you are upgrading from AMA to SMB, you have to change it manualy
 * Note when building AndroidAPS 2.0 apk: Configuration on demand is not supported by the current version of the Android Gradle plugin! If your build fails with an error regarding "on demand configuration" you can do the following:
 
-   * Open the Preferences window by clicking File > Settings (on Mac, Android Studio > Preferences).
-   * In the left pane, click Build, Execution, Deployment > Compiler.
-   * Uncheck the Configure on demand checkbox.
-   * Click Apply or OK.
+  * Open the Preferences window by clicking File > Settings (on Mac, Android Studio > Preferences).
+  * In the left pane, click Build, Execution, Deployment > Compiler.
+  * Uncheck the Configure on demand checkbox.
+  * Click Apply or OK.
 
 Overview tab
 --------------------------------------------------
@@ -360,7 +360,7 @@ Misc
 * Overhaul for config builder and objectives tabs, adding descriptions
 * New app icon
 * Lots of improvements and bugfixes
-* Nightscout-independant alerts if pump is unreachable for a longer time (e.g. depleted pump battery) and missed BG readings (see _Local alerts_ in settings)
+* Nightscout-independant alerts if pump is unreachable for a longer time (e.g. depleted pump battery) and missed BG readings (see *Local alerts* in settings)
 * Option to keep screen on
 * Option to show notification as Android notification
 * Advanced filtering (allowing to always enable SMB and 6h after meals) supported with patched Dexcom app or xDrip with G5 native mode as BG source.

--- a/docs/EN/Installing-AndroidAPS/troubleshooting_androidstudio.rst
+++ b/docs/EN/Installing-AndroidAPS/troubleshooting_androidstudio.rst
@@ -103,8 +103,8 @@ Option 3 - Check for updates
 * Switch to Terminal in Android Studio (lower left side of Android Studio window)
 
   .. image:: ../images/GIT_TerminalCheckOut1.PNG
-  :alt: Android Studio Terminal
-   
+    :alt: Android Studio Terminal
+
 * Paste copied text and press return
 
   .. image:: ../images/GIT_TerminalCheckOut2.jpg
@@ -134,10 +134,9 @@ None of the above worked
 If non of the above tips helped you might consider building the app from scratch:
 
 1. `Export settings <../Usage/ExportImportSettings.html>`_ (in AAPS version already installed on your phone)
-2. Have your key password and key store password ready
-    In case you have forgotten passwords you can try to find them in project files as described `here <https://youtu.be/nS3wxnLgZOo>`_. Or you just use a new keystore. 
+2. Have your key password and key store password ready. In case you have forgotten passwords you can try to find them in project files as described `here <https://youtu.be/nS3wxnLgZOo>`_. Or you just use a new keystore. 
 3. Build app from scratch as described `here <../Installing-AndroidAPS/Building-APK.html#download-androidaps-code>`_.
-4.	When you have build the APK successfully delete the exiting app on your phone, transfer the new apk to your phone and install.
+4. When you have build the APK successfully delete the exiting app on your phone, transfer the new apk to your phone and install.
 5. `Import settings <../Usage/ExportImportSettings.html>`_
 
 Worst case scenario

--- a/docs/EN/Module/module.rst
+++ b/docs/EN/Module/module.rst
@@ -17,7 +17,7 @@ AndroidAPS is not just a (self-built) application, it is just one of serveral mo
 Necessary Modules
 ==================================================
 Good individual dosage algorithm for your diabetes therapy
---------------------------------------------------
+----------------------------------------------------------
 Even though this is not something to create or buy, this is the 'module' which is probably underestimated the most but essential. When you let an algorithm help manage your diabetes, it needs to know the right settings to not make severe mistakes.
 Even if you are still missing other modules, you can already verify and adapt your 'profile' in collaboration with your diabetes team. 
 Most loopers use circadian BR, ISF and CR, which adapt hormonal insulin sensitivity during the day.

--- a/docs/EN/Resources/clinician-guide-to-AndroidAPS.md
+++ b/docs/EN/Resources/clinician-guide-to-AndroidAPS.md
@@ -2,14 +2,14 @@
 
 This page is intended for clinicians who have expressed interest in open source artificial pancreas technology such as AndroidAPS, or for patients who want to share such information with their clinicians. 
 
-This guide has some high-level information about DIY closed looping and specifically how AndroidAPS works. For more details on all of these topics, please view the [comprehensive AndroidAPS documentation online](http://androidaps.readthedocs.io/en/latest/index.html). If you have questions, please ask your patient for more details, or always feel free to reach out to the community with question. (If you’re not on social media (e.g. [Twitter](https://twitter.com/kozakmilos) or Facebook), feel free to email developers@AndroidAPS.org). [You can also find some of the latest studies & outcomes related data here](https://openaps.org/outcomes/).
+This guide has some high-level information about DIY closed looping and specifically how AndroidAPS works. For more details on all of these topics, please view the [comprehensive AndroidAPS documentation online](../index.rst). If you have questions, please ask your patient for more details, or always feel free to reach out to the community with question. (If you’re not on social media (e.g. [Twitter](https://twitter.com/kozakmilos) or Facebook), feel free to email developers@AndroidAPS.org). [You can also find some of the latest studies & outcomes related data here](https://openaps.org/outcomes/).
 
 ### The steps for building a DIY Closed Loop:
 
 To start using AndroidAPS, the following steps should be taken:
-* Find a [compatible pump](../Hardware/pumps.rst), a [compatible Android device](https://docs.google.com/spreadsheets/d/1gZAsN6f0gv6tkgy9EBsYl0BQNhna0RDqA9QGycAqCQc/edit?usp=sharing), and a [compatible CGM source](https://androidaps.readthedocs.io/en/latest/EN/index.html#getting-started).
-* [Download the AndroidAPS source code and build the software](https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Building-APK.html).
-* [Configure the software to talk to their diabetes devices and specify settings and safety preferences](https://androidaps.readthedocs.io/en/latest/EN/index.html#configuration).
+* Find a [compatible pump](../Hardware/pumps.rst), a [compatible Android device](https://docs.google.com/spreadsheets/d/1gZAsN6f0gv6tkgy9EBsYl0BQNhna0RDqA9QGycAqCQc/edit?usp=sharing), and a [compatible CGM source](../index.rst#getting-started).
+* [Download the AndroidAPS source code and build the software](../Installing-AndroidAPS/Building-APK.md).
+* [Configure the software to talk to their diabetes devices and specify settings and safety preferences](../index.rst#configuration).
 
 ### How A DIY Closed Loop Works
 

--- a/docs/EN/Usage/Automation.rst
+++ b/docs/EN/Usage/Automation.rst
@@ -88,14 +88,14 @@ After adding your action, **don't forget to change the default values** to what 
   :alt: Automation default vs. set values
 
 Sort automation rules
------
+---------------------
 To sort automation rules click and hold the four-lines-button on the right side of the screen and move up or down.
 
 .. image:: ../images/Automation_Sort.png
   :alt: Sort automation rules
   
 Delete automation rules
------
+-----------------------
 To delete an automation rule click on trash icon.
 
 .. image:: ../images/Automation_Delete.png

--- a/docs/EN/Usage/Extended-Carbs.rst
+++ b/docs/EN/Usage/Extended-Carbs.rst
@@ -30,9 +30,9 @@ A way to handle fat and protein with that feature is described here: `https://ad
 
 -----
 
-The recommended setup is to use the OpenAPS SMB APS plugin, with SMBs enabled as well as the _Enable SMB with COB_ preference being enabled.
+The recommended setup is to use the OpenAPS SMB APS plugin, with SMBs enabled as well as the *Enable SMB with COB* preference being enabled.
 
-A scenario e.g. for a Pizza might be to give a (partial) bolus up front via the _calculator_ and then use the _carbs_ button to enter the remaining carbs for a duration of 4-6 hours, starting after 1 or 2 hours. You'll need to try out and see which concrete values work for you of course. You might also carefully adjust the setting _max minutes of basal to limit SMB to_ to make the algorithm more or less aggressive.
+A scenario e.g. for a Pizza might be to give a (partial) bolus up front via the *calculator* and then use the *carbs* button to enter the remaining carbs for a duration of 4-6 hours, starting after 1 or 2 hours. You'll need to try out and see which concrete values work for you of course. You might also carefully adjust the setting *max minutes of basal to limit SMB to* to make the algorithm more or less aggressive.
 With low carb, high fat/protein meals it may be enough to only use eCarbs without manual boluses (see the blog post above).
 
 When eCarbs are generated, a Careportal note is also created to document all inputs, to make it easier to iterate and improve inputs.

--- a/docs/EN/Usage/SonySW3.rst
+++ b/docs/EN/Usage/SonySW3.rst
@@ -9,12 +9,12 @@ The following workaround should extend the time the Sony Smartwatch 3 can be use
 --------------------------------------------------------
 * Using `apkmirror website <https://www.apkmirror.com/apk/google-inc/google-play-services-android-wear/>`_ you can find the latest apk for "Google Play Services (Wear OS)".
 
-   Architecture: armeabi-v7a, Minimum Version: Android 6.0+, Screen DPI: nodpi
+  Architecture: armeabi-v7a, Minimum Version: Android 6.0+, Screen DPI: nodpi
 
 * You must ensure 2 things:
 
-   * Is it the latest version?
-   * Is it compatible with Android 6.0+ (as it's the wear android version, 7.0+ and above will not work)?
+  * Is it the latest version?
+  * Is it compatible with Android 6.0+ (as it's the wear android version, 7.0+ and above will not work)?
 
 * Sooner or later, Google will definitely drop Android 6.0. When this will happen, the latest version will not be available anymore for Android 6.0+, therefore it will be the end.
 
@@ -47,12 +47,12 @@ The following workaround should extend the time the Sony Smartwatch 3 can be use
 --------------------------------------------------------
 * In terminal enter this command „adb install -r -g aplicationname.apk“ (so in our case „adb install -r -g SW3fix.apk“).
 
-   .. image:: ../images/SonySW3_Terminal1.png
-     :alt: Terminal command
+  .. image:: ../images/SonySW3_Terminal1.png
+    :alt: Terminal command
 
 * Wait for about 4–5 minutes for installation to complete. 
 
-.. image:: ../images/SonySW3_Terminal2.png
-     :alt: Terminal successful installation
+  .. image:: ../images/SonySW3_Terminal2.png
+    :alt: Terminal successful installation
 
 * Once it's done, restart your watch and you should see the apps beginning to synchronize themself promptly.

--- a/docs/EN/Usage/troubleshooting.rst
+++ b/docs/EN/Usage/troubleshooting.rst
@@ -6,10 +6,12 @@ Additional useful information might also be available in the `FAQ <../Getting-St
 
 AndroidAPS app
 ==================================================
+
 Building & updating
------
+-------------------
 * `Lost keystore <../Installing-AndroidAPS/troubleshooting_androidstudio.html#lost-keystore>`_
 * `Troubleshooting AndroidStudio <../Installing-AndroidAPS/troubleshooting_androidstudio.html>`_
+
 Settings
 --------------------------------------------------
 * `Profile <../Usage/Profiles.html#troubleshooting-profile-errors>`_
@@ -18,6 +20,7 @@ Settings
     :alt: Error: Basal not aligned to hours
 
 * `Nightscout Client <../Usage/Troubleshooting-NSClient.html>`_
+
 Usage
 --------------------------------------------------
 * `Wrong carb values <../Usage/COB-calculation.html#detection-of-wrong-cob-values>`_

--- a/docs/EN/make-a-PR.md
+++ b/docs/EN/make-a-PR.md
@@ -79,9 +79,9 @@ If using images please use reasonable sizes. Screenshot images should be **250 p
 * images: `![alt text](../images/file.png)`
 #### Links
 * external link: `[alt text](www.url.tld)`
-* internal link to .md page: `[alt text](.../folder/file.md)`
-* internal link to .rst page: `[alt text](.../folder/file.rst)`
-* internal link to headline: `[alt text](.../folder/file#headline)`
+* internal link to .md page: `[alt text](../folder/file.md)`
+* internal link to .rst page: `[alt text](../folder/file.rst)`
+* internal link to headline: `[alt text](../folder/file#headline)`
 
 ### .rst files
 #### Text format


### PR DESCRIPTION
The total repo has over 11.000 warning during build. This is unhealthy practice too keep them in. This will prevent us from upgrading in the future. Some the fixes are `code` cosmetic and some are broken links or incorrect use of md and rst format.

The first target is to get all warning from the source language English. And there after in priority of % translated languages. 

This PR fixes over 300 warning, fixing various issues:
- indents with 3 spaces, => 2 spaces
- horizontal line is not allowed as first item after a heading => removed line
- some .rst italic was written with underscores (as in .md) but they are links in rst => replace _ with *
- some * (italic) are not where not closed => add closing *
- some list contained a newline => removed newline
- Some rst headers where to short => made the longer
- rst lists should end with a empty line => added extra line
- some alt text was wrong indented, causes not to match with the image => added spaces

The PR in independent of #969 