### PR TITLE
Update module.rst: AndroidAPS does not support all Enlite sensors.

### DIFF
--- a/docs/EN/Module/module.rst
+++ b/docs/EN/Module/module.rst
@@ -82,7 +82,7 @@ This is just a short overview of all compatible CGMs/FGM with AndroidAPS. For fu
 * `Libre 2 <../Hardware/Libre2.html>`_: It works with xDrip+ (no transmitter needed), but you have to build your own patched app.
 * `Libre 1 <../Hardware/Libre1.html>`_: You need a transmitter like Bluecon or MiaoMiao for it (build or buy) and xDrip+ app
 * `Eversense <../Hardware/Eversense.html>`_: It works so far only in combination with ESEL app and a patched Eversense-App (works not with Dana RS and LineageOS, but DanaRS and Android or Combo and Lineage OS work fine)
-* `MM640g/MM630g <../Hardware/MM640g.html>`_: quite complicated with a lot of extra stuff
+* `Enlite (MM640G/MM630G) <../Hardware/MM640g.html>`_: quite complicated with a lot of extra stuff
 
 
 Nightscout

--- a/docs/EN/Module/module.rst
+++ b/docs/EN/Module/module.rst
@@ -82,7 +82,7 @@ This is just a short overview of all compatible CGMs/FGM with AndroidAPS. For fu
 * `Libre 2 <../Hardware/Libre2.html>`_: It works with xDrip+ (no transmitter needed), but you have to build your own patched app.
 * `Libre 1 <../Hardware/Libre1.html>`_: You need a transmitter like Bluecon or MiaoMiao for it (build or buy) and xDrip+ app
 * `Eversense <../Hardware/Eversense.html>`_: It works so far only in combination with ESEL app and a patched Eversense-App (works not with Dana RS and LineageOS, but DanaRS and Android or Combo and Lineage OS work fine)
-* `Enlite <../Hardware/MM640g.html>`_: quite complicated with a lot of extra stuff
+* `MM640g/MM630g <../Hardware/MM640g.html>`_: quite complicated with a lot of extra stuff
 
 
 Nightscout


### PR DESCRIPTION
AndroidAPS does not support all Enlite sensors, for example, the MMT-7008 model. It only supports MM640g/MM630g models of Enlite.