### PR TITLE
Update OmnipodEros.rst

### DIFF
--- a/docs/EN/Configuration/OmnipodEros.rst
+++ b/docs/EN/Configuration/OmnipodEros.rst
@@ -138,7 +138,7 @@ Before you can activate a pod please ensure you have properly configured and con
 
     |Activate_Pod_1| |Activate_Pod_2|
 
-2. The **Fill Pod** screen is displayed. Fill a new pod with at least 85 units of insulin and listen for two beeps indicating that the pod is ready to be primed.
+2. The **Fill Pod** screen is displayed. Fill a new pod with at least 80 units of insulin and listen for two beeps indicating that the pod is ready to be primed. When calculating the total amount of insulin you need for 3 days, please take into account that priming the pod will use 12 to 15 units. 
 
     |Activate_Pod_3|
 


### PR DESCRIPTION
1 small change and 1 added information : The Omnipod needs only 80U to be primed (and not 85U as indicated in the doc). I have tested this several times (dosing 80U precisely using a insulin pen to fill the pod).

It would be helpful to know that 12-15 units will be used to prime the pod and thus will not be available for normal usage during the 3 days. I usually see 14U used for priming but I'm not 100% sure that it is systematically 14...