### PR TITLE
Added Suggestion to force shutdown of AAPS during pairing

### DIFF
--- a/docs/CROWDIN/de/Configuration/Accu-Chek-Combo-Pump.md
+++ b/docs/CROWDIN/de/Configuration/Accu-Chek-Combo-Pump.md
@@ -87,6 +87,8 @@ Es sind verschiedene Gründe möglich. Versuche die folgenden Schritte:
 
 1. Lege eine **neue oder volle Batterie** in die Pumpe ein. Sieh Dir den Batterie-Abschnitt für Details an. Stelle sicher, dass die Pumpe sich sehr nahe am Smartphone befindet.
 
+-Falls AndroidAPS bereits läuft: Stoppe den Loop und beende AAPS auf deinem Smartphone über Einstellungen->Apps&Benachrichtigungen->AndroidAPS->Beenden erzwingen
+
 ![Combo sollte sich direkt bei dem Smartphone befinden](../images/Combo_next_to_Phone.png)
 
 2. Schalte andere Bluetoothgeräte aus oder entferne sie, damit sie keine Verbindung zu dem Smartphone aufzubauen, während die Kopplung durchgeführt wird. Jede gleichzeitige Bluetooth-Kommunikation oder Eingabeaufforderung, eine Verbindung herzustellen, kann den Kopplungs-Prozess stören.


### PR DESCRIPTION
Shutting down AAPS helped me to pair a new Combo-Pump. Having paired another pump prior I was not able to pair a new Pump until I stopped AAPS completely (not just the loop). With AAPS down pairing ran instantly :)