### PR TITLE
Improved searchability for OrangeLink and EmaLink switch

### DIFF
--- a/docs/EN/Configuration/OmnipodEros.rst
+++ b/docs/EN/Configuration/OmnipodEros.rst
@@ -623,7 +623,7 @@ Provides advanced settings to assist debugging.
 Switching or Removing an Active Pod Communication Device (RileyLink)
 --------------------------------------------------------------------
 
-With many alternative models to the original RileyLink available or the need have multiple/backup versions of the same pod communication device (RileyLink), it becomes necessary to switch or remove the selected pod communication device (RileyLink) from Omnipod Setting configuration. 
+With many alternative models to the original RileyLink available (such as OrangeLink or EmaLink) or the need to have multiple/backup versions of the same pod communication device (RileyLink), it becomes necessary to switch or remove the selected pod communication device (RileyLink) from Omnipod Setting configuration. 
 
 The following steps will show how to **Remove** and existing pod communication device (RileyLink) as well as **Add** a new pod communication device.  Executing both **Remove** and **Add** steps will switch your device.
 


### PR DESCRIPTION
Added OrangeLink and EmaLink as possible alternatives for RileyLink to switch over from and to. This will improve searchability if someone simply searched for the term OrangeLink to find the proper instructions.