### PR TITLE
Adding "Recommended specification" on the docs

### DIFF
--- a/docs/EN/Installing-AndroidAPS/Building-APK.md
+++ b/docs/EN/Installing-AndroidAPS/Building-APK.md
@@ -54,7 +54,7 @@ If your build fails with an error regarding "on demand configuration" you can do
 </tbody>
 </table>
 
-Please be in mind that both 64 bit CPU and 64 bit OS are mandatory condition. If your system DOES NOT meet this condition, you have to change affected hardware or software or the whole system. It is strongly recommended to use SSD(Solid State Disk) instead of HDD(Hard Disk Drive) because it will take less time when you are building the APS installation apk file. Recommended is just recommended and it is not a mandatory. You may still use a HDD when you are building apk file if you can spend a long time ALONE to complete the build.
+Please be in mind that both **64 bit CPU and 64 bit OS are mandatory condition.** If your system DOES NOT meet this condition, you have to change affected hardware or software or the whole system. **It is strongly recommended to use SSD(Solid State Disk) instead of HDD(Hard Disk Drive) because it will take less time when you are building the APS installation apk file.** Recommended is just recommended and it is not a mandatory. However, you may still use a HDD when you are building apk file if you can spend a long time ALONE to complete the build.
    
 ---
 ### This article is divided into two parts.

--- a/docs/EN/Installing-AndroidAPS/Building-APK.md
+++ b/docs/EN/Installing-AndroidAPS/Building-APK.md
@@ -16,6 +16,45 @@ If your build fails with an error regarding "on demand configuration" you can do
 * In the left pane, click Build, Execution, Deployment > Compiler.
 * Uncheck the Configure on demand checkbox.
 * Click Apply or OK.
+
+## Recommended specification of computer for building apk file
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-baqh">OS(Only 64 bit)</th>
+    <th class="tg-baqh">Windows 8 or higher</th>
+    <th class="tg-baqh">Mac OS 10.14 or higher</th>
+    <th class="tg-baqh">Any Linux supports Gnome, KDE, or Unity DE;&nbsp;&nbsp;GNU C Library 2.31 or later</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-baqh"><p align="center">CPU(Only 64 bit)</td>
+    <td class="tg-baqh">x86_64 CPU architecture; 2nd generation Intel Core or newer, or AMD CPU with support for a <br><a href="https://developer.android.com/studio/run/emulator-acceleration#vm-windows" target="_blank" rel="noopener noreferrer"><span style="text-decoration:var(--devsite-link-text-decoration,none)">Windows Hypervisor</span></a></td>
+    <td class="tg-baqh">ARM-based chips, or 2nd generation Intel Core or newer with support for <br><a href="https://developer.android.com/studio/run/emulator-acceleration#vm-mac" target="_blank" rel="noopener noreferrer"><span style="text-decoration:var(--devsite-link-text-decoration,none)">Hypervisor.Framework</span></a></td>
+    <td class="tg-baqh">x86_64 CPU architecture; 2nd generation Intel Core or newer, or AMD processor with support for AMD Virtualization (AMD-V) and SSSE3</td>
+  </tr>
+  <tr>
+    <td class="tg-baqh"><p align="center">RAM</td>
+    <td class="tg-baqh" colspan="3"><p align="center">8GB or more</td>
+  </tr>
+  <tr>
+    <td class="tg-baqh"><p align="center">Disk</td>
+    <td class="tg-baqh" colspan="3"><p align="center">At least 30GB free space. SSD is recommended.</td>
+  </tr>
+  <tr>
+    <td class="tg-baqh"><p align="center">Resolution</td>
+    <td class="tg-baqh" colspan="3"><p align="center">1280 x 800 Minimum <br></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh"><p align="center">Internet</td>
+    <td class="tg-baqh" colspan="3"><p align="center">Broadband</td>
+  </tr>
+</tbody>
+</table>
+
+It is strongly recommended to use SSD(Solid State Disk) instead of HDD(Hard Disk Drive) because it will take less time when you are building apk file. 
    
 ---
 ### This article is divided into two parts.

--- a/docs/EN/Installing-AndroidAPS/Building-APK.md
+++ b/docs/EN/Installing-AndroidAPS/Building-APK.md
@@ -54,7 +54,7 @@ If your build fails with an error regarding "on demand configuration" you can do
 </tbody>
 </table>
 
-It is strongly recommended to use SSD(Solid State Disk) instead of HDD(Hard Disk Drive) because it will take less time when you are building apk file. 
+Please be in mind that both 64 bit CPU and 64 bit OS are mandatory condition. If your system DOES NOT meet this condition, you have to change affected hardware or software or the whole system. It is strongly recommended to use SSD(Solid State Disk) instead of HDD(Hard Disk Drive) because it will take less time when you are building the APS installation apk file. Recommended is just recommended and it is not a mandatory. You may still use a HDD when you are building apk file if you can spend a long time ALONE to complete the build.
    
 ---
 ### This article is divided into two parts.


### PR DESCRIPTION
Hello, 
I have experienced many cases taking a long time to build apk file while I was helping other people. All they were using systems below the recommended specification. 
For example, using 4GB RAM or HDD slowed down whole process. For this reason, I would like to add "Recommended specification of computer for building apk file" on the docs. 
Please assess my draft and any comment would be welcome.
Thanks.