### PR TITLE
Update Preferences.rst

### DIFF
--- a/docs/EN/Configuration/Preferences.rst
+++ b/docs/EN/Configuration/Preferences.rst
@@ -49,6 +49,7 @@ Protection
 Master password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Necessary to be able to `export settings <../Usage/ExportImportSettings.html>`_ as they are encrypted as of version 2.7.
+  **Biometric protection may not work on OnePlus phones. This is a know issue of OnePlus on some phones.**
 
 * Open Preferences (three-dot-menu on top right of home screen)
 * Click triangle below "General"

--- a/docs/EN/Configuration/Preferences.rst
+++ b/docs/EN/Configuration/Preferences.rst
@@ -49,7 +49,6 @@ Protection
 Master password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Necessary to be able to `export settings <../Usage/ExportImportSettings.html>`_ as they are encrypted as of version 2.7.
-  **Biometric protection does not work on OnePlus phones. This is a know issue of OnePlus.**
 
 * Open Preferences (three-dot-menu on top right of home screen)
 * Click triangle below "General"


### PR DESCRIPTION
As a oneplus 7T user, I haven't noticed a problem with biometrics protection in AAPS, I suggest to delete the comment about oneplus:  "Biometric protection does not work on OnePlus phones. This is a know issue of OnePlus."