### PR TITLE
non byoda patched app chapter is obsolete

### DIFF
--- a/docs/EN/Hardware/DexcomG6.rst
+++ b/docs/EN/Hardware/DexcomG6.rst
@@ -29,26 +29,6 @@ If using G6 with xDrip+
 * Adjust settings in xDrip+ according to `xDrip+ settings page <../Configuration/xdrip.html>`__
 * If AAPS does not receive BG values when phone is in airplane mode use 'Identify receiver' as describe on `xDrip+ settings page <../Configuration/xdrip.html>`__.
 
-If using G6 with patched Dexcom app
-==================================================
-* Download the apk from `https://github.com/dexcomapp/dexcomapp <https://github.com/dexcomapp/dexcomapp>`_, and choose the version that fits your needs (mg/dl or mmol/l version, G6).
-
-  * Folder 2.4 for users of the current version, folder 2.3 is only for the outdated AndroidAPS 2.3.
-  * Open https://play.google.com/store/search?q=dexcom%20g6 on your computer. 
-  * Click the link to the Dexcom G6 app on the search results page that is displayed.
-  * Region will be visible in URL.
-
-  .. image:: ../images/DexcomG6regionURL.PNG
-    :alt: Region in Dexcom G6 URL
-
-* Uninstall the original Dexcom app.
-* Install downloaded apk
-* Enter sensor code and transmitter serial no. in patched app.
-* After short time patched app should pick-up transmitter signal. (If not you will have to stop sensor and start new one.)
-* Select Dexcom App (patched) in ConfigBuilder (setting in AndroidAPS).
-* If you want to use xDrip+ alarms via local broadcast: in xDrip+ hamburger menu > settings > hardware data source > 640G /EverSense.
-* There is no local broadcast from patched Dexcom app directly to xDrip+. Broadcast has to go through AAPS as described above.
-
 If using G6 with Build Your Own Dexcom App
 ==================================================
 * As of December 2020 `Build Your Own Dexcom App <https://docs.google.com/forms/d/e/1FAIpQLScD76G0Y-BlL4tZljaFkjlwuqhT83QlFM5v6ZEfO7gCU98iJQ/viewform?fbzx=2196386787609383750&fbclid=IwAR2aL8Cps1s6W8apUVK-gOqgGpA-McMPJj9Y8emf_P0-_gAsmJs6QwAY-o0>`_ (BYODA)also supports local broadcast to AAPS and/or xDrip+ (not for G5 sensors!)


### PR DESCRIPTION
The chapter "If using G6 with patched Dexcom app" is obsolete