### PR TITLE
update to text in Pump choices to match AAPS 3.0.0

### DIFF
--- a/docs/EN/Getting-Started/Pump-Choices.md
+++ b/docs/EN/Getting-Started/Pump-Choices.md
@@ -5,9 +5,12 @@ AndroidAPS currently works with
 - Accu-Chek Combo
 - Accu-Chek Insight
 - some old Medtronic
-- Insulet Omnipod (Eros not DASH)
+- Insulet Omnipod DASH (as of AAPS 3.0.0)
+- Insulet Omnipod Eros
 - DanaR
-- DanaRS  
+- DanaRS
+- Dana-i (as of AAPS 3.0.0)
+- Diaconn G8 (as of AAPS 3.0.0)
 
 pumps. Details of the status of other pumps that may have the potential to work with AndroidAPS are listed on the [Future (possible) Pumps](Future-possible-Pump-Drivers.md) page.
 
@@ -24,6 +27,8 @@ The Combo and the Insight are solid pumps, and loopable. The advantages of the D
 * The Combo vibrates on the end of TBRs, the Dana* R vibrates (or beeps) on SMB. At night time you are likely to be using TBRs more than SMB.  The Dana* RS is configurable that it does neither beeps or vibrates.
 
 * Reading the history on the RS in a few seconds with carbs makes it possible to switch phones easily while offline and continue looping as soon a soon as some CGM values are in.
+
+* Insulet Omnipod Eros requires a pod communication device such as RileyLink/Orangelink etc. The newer omnipod DASH does not since it communicates with your phone directly via Bluetooth.
 
 * All pumps AndroidAPS can talk with are waterproof on delivery. Only the Dana pumps are also "waterproof by warranty" due to the sealed battery compartment and reservoir filling system. 
 


### PR DESCRIPTION
added DASH,G8 and DANA-i to list and a comment about connection requirements of omnipods.