### PR TITLE
Update FAQ.md

### DIFF
--- a/docs/EN/Getting-Started/FAQ.md
+++ b/docs/EN/Getting-Started/FAQ.md
@@ -118,9 +118,9 @@ Then take an estimated amount of insulin (as per current 1/ISF) to get to your t
 
 Be careful as this is quite often set too low. Too low means 1 U will drop BG faster than expected.
 ### Impact
-**Lower ISF** (i.e. 40 instead of 50) meaning a smaller drop in bg for one unit of insulin. This means a more aggressive / stronger correction with **more insulin**. If the ISF is too low, this can lead to low BGs.
+**Lower ISF** (i.e. 40 instead of 50) meaning insulin drops your BG less per unit. This leads to a more aggressive / stronger correction with **more insulin**. If the ISF is too low, this can lead to low BGs.
 
-**Higher ISF** (i.e. 45 instead of 35) meaning a larger drop in bg for one unit of insulin. This means a less aggressive / weaker correction with **less insulin**. If the ISF is too high, this can lead to high BGs.
+**Higher ISF** (i.e. 45 instead of 35) meaning insulin drops your BG more per unit. This leads to a less aggressive / weaker correction with **less insulin**. If the ISF is too high, this can lead to high BGs.
 
 **Example:** 
 * BG is 190 mg/dl (10,5 mmol) and target is 100 mg/dl (5,6 mmol). 

--- a/docs/EN/Getting-Started/FAQ.md
+++ b/docs/EN/Getting-Started/FAQ.md
@@ -118,9 +118,9 @@ Then take an estimated amount of insulin (as per current 1/ISF) to get to your t
 
 Be careful as this is quite often set too low. Too low means 1 U will drop BG faster than expected.
 ### Impact
-**Lower ISF** (i.e. 40 instead of 50) meaning insulin drops your BG less per unit. This leads to a more aggressive / stronger correction with **more insulin**. If the ISF is too low, this can lead to low BGs.
+**Lower ISF** (i.e. 40 instead of 50) meaning insulin drops your BG less per unit. This leads to a more aggressive / stronger correction from the loop with **more insulin**. If the ISF is too low, this can lead to low BGs.
 
-**Higher ISF** (i.e. 45 instead of 35) meaning insulin drops your BG more per unit. This leads to a less aggressive / weaker correction with **less insulin**. If the ISF is too high, this can lead to high BGs.
+**Higher ISF** (i.e. 45 instead of 35) meaning insulin drops your BG more per unit. This leads to a less aggressive / weaker correction from the loop with **less insulin**. If the ISF is too high, this can lead to high BGs.
 
 **Example:** 
 * BG is 190 mg/dl (10,5 mmol) and target is 100 mg/dl (5,6 mmol). 

--- a/docs/EN/Getting-Started/FAQ.md
+++ b/docs/EN/Getting-Started/FAQ.md
@@ -118,9 +118,9 @@ Then take an estimated amount of insulin (as per current 1/ISF) to get to your t
 
 Be careful as this is quite often set too low. Too low means 1 U will drop BG faster than expected.
 ### Impact
-**Lower ISF** (i.e. 40 instead of 50) = more aggressive / stronger leading to a bigger drop in BGs for each unit of insulin. If too low, this can lead to low BGs.
+**Lower ISF** (i.e. 40 instead of 50) meaning a smaller drop in bg for one unit of insulin. This means a more aggressive / stronger correction with **more insulin**. If the ISF is too low, this can lead to low BGs.
 
-**Higher ISF** (i.e. 45 instead of 35) = less aggressive / weaker leading to a smaller drop in BGs for each unit of insulin. If too high, this can lead to high BGs.
+**Higher ISF** (i.e. 45 instead of 35) meaning a larger drop in bg for one unit of insulin. This means a less aggressive / weaker correction with **less insulin**. If the ISF is too high, this can lead to high BGs.
 
 **Example:** 
 * BG is 190 mg/dl (10,5 mmol) and target is 100 mg/dl (5,6 mmol). 


### PR DESCRIPTION
I noticed an error in the explanation of ISF in the FAQ for Loopers part of the docs:
It was explaining that a higher ISF leads to a smaller drop in BG for one unit of insulin and vice versa. I have edited the text to be more clear and made a distinction between wat the ISF means and what it leads to.