### PR TITLE
Omnipod Dash: Add Android12 + pod firmware3.XX.X note

### DIFF
--- a/docs/EN/Configuration/OmnipodDASH.md
+++ b/docs/EN/Configuration/OmnipodDASH.md
@@ -25,7 +25,8 @@ These are the specifications of the **Omnipod DASH** and what differentiates it 
 * **Compatible Android phone** with a BLE Bluetooth connection  
    -  Not all phone hardware and Android versions are guaranteed to work.
 Please check [**DASH Tested phones**](https://docs.google.com/spreadsheets/d/1zO-Vf3wv0jji5Gflk6pe48oi348ApF5RvMcI6NG5TnY) or just try with your phone and tell us the result (phone reference and geographical region, Android version, worked / some difficulties / did not work).
-   -  **For some phone models, this might be an issue** : **Be aware that AAPS Omnipod Dash driver Connects with the Dash POD via Bluetooth every time it sends a command, and it disconnects right after. The Bluetooth connections might be disturbed by other devices linked to the phone that is running AAPS, like earbuds etc... (which might cause, in rare occasions, connection issue or pod errors/loss on activation or afterwards in some phone models), or be disturbed by it.**
+   - **Important note: There have been multiple cases of permanent, non-recoverable connection losses when using Android 12 together with pod that have firmware version 3.XX.X. Avoid using Android 12 with these old firmware pods for now!**  
+   Be aware that AAPS Omnipod Dash driver Connects with the Dash POD via Bluetooth every time it sends a command, and it disconnects right after. The Bluetooth connections might be disturbed by other devices linked to the phone that is running AAPS, like earbuds etc... (which might cause, in rare occasions, connection issue or pod errors/loss on activation or afterwards in some phone models), or be disturbed by it.  
    -  **Version 3.0 or newer of AndroidAPS built and installed** using the [**Build APK**](../Installing-AndroidAPS/Building-APK.html#) instructions.
 * [**Continuous Glucose Monitor (CGM)**](https://androidaps.readthedocs.io/en/latest/Configuration/BG-Source.html)
 


### PR DESCRIPTION
As [mentioned](https://discord.com/channels/629952586895851530/817392867995680768/947636274045517865) I have added a note that Android 12 + pods with old firmware (3.XX.X, confirmed cases are mostly 3.29.0) commonly have these permanent, non-recoverable connection losses and that this setup combination should be avoided for now.

If you have any preferences about a different formatting, dont hesitate to request changes.

