### PR TITLE
correted typo in link to Jelly Pro Settings

### DIFF
--- a/docs/EN/Hardware/Phoneconfig.md
+++ b/docs/EN/Hardware/Phoneconfig.md
@@ -1,5 +1,5 @@
 # Phones
 
 - [List of tested phones](../Getting-Started/Phones.md)
-- [Jelly Pro Settings](../Usage/jelly.md>)
+- [Jelly Pro Settings](../Usage/jelly.md)
 - [Huawei Settings](../Usage/huawei.md)


### PR DESCRIPTION
correted typo in link to Jelly Pro Settings