### PR TITLE
Update xdrip.md for pump control related config

### DIFF
--- a/docs/EN/Configuration/xdrip.md
+++ b/docs/EN/Configuration/xdrip.md
@@ -46,8 +46,8 @@ If your phone runs Android 10 and you have difficulties with xDrip+ master try [
 
 ### Identify receiver
 
-* If you discover problems with local broadcast (AAPS not receiving BG values from xDrip+) go to Settings > Inter-app settings > Identify receiver and enter `info.nightscout.androidaps`.
-* Pay attention: Auto-correction sometimes tend to change i to capital letter. You **must use only lowercase letters** when typing `info.nightscout.androidaps`. Capital I would prevent AAPS from receiving BG values from xDrip+.
+* If you discover problems with local broadcast (AAPS not receiving BG values from xDrip+) go to Settings > Inter-app settings > Identify receiver and enter `info.nightscout.androidaps` for AndroidAPS build (if you are using PumpControl build, please enter `info.nightscout.aapspumpcontrol` instead!!).
+* Pay attention: Auto-correction sometimes tend to change i to capital letter. You **must use only lowercase letters** when typing `info.nightscout.androidaps` (or `info.nightscout.aapspumpcontrol` for PumpControl). Capital I would prevent the App from receiving BG values from xDrip+.
 
    ![xDrip+ Basic Inter-app Settings Identify receiver](../images/xDrip_InterApp_NS.png)
 


### PR DESCRIPTION
When using `pump control` build variant, package name of the app is different than for `AndroidAPS` build mode.
And so different config of `xdrip+` is needed in order to receive BG from `xdrip+` in `pump control`.