### PR TITLE
Update update3_0.md

### DIFF
--- a/docs/EN/Installing-AndroidAPS/update3_0.md
+++ b/docs/EN/Installing-AndroidAPS/update3_0.md
@@ -36,7 +36,7 @@
 * You need to add a file named ```PasswordReset``` to the ```/AAPS/extra``` directory on your phones fileystem.
 * Restart AndroidAPS.
 * The new password will be the serial number of your active pump.
-* For Dash: The serial number is always 4242.
+* For Dash: The serial number is always 4241.
 * For EROS it is also listed on the POD tab as "Sequence Number"
 
 ## Warning signal beneath BG


### PR DESCRIPTION
Correction to Omnipod Dash default password after reset.
Verified 4241 as working in Australia; corollary - 4242 did not work as expected.
Obtained from:
https://docs.google.com/document/d/1jNepAg8h6Ge08Wckn9bQCa1zdcZBLRc5A0p_LcP1np4/edit?usp=drivesdk