### PR TITLE
Update EOPatch2.md

### DIFF
--- a/docs/EN/Configuration/EOPatch2.md
+++ b/docs/EN/Configuration/EOPatch2.md
@@ -1,5 +1,7 @@
 # EOPatch2 Instruction Manual
 
+**Planned but not commited for AndrdoidAPS 3.2!**
+
 The patch requires the use of rapid-acting U-100 type insulin, such as NovoRapid or Humalog. Use a rapid-acting insulin that is suitable for you according to your doctor’s prescription and inject the prescribed dosage.
 
 The smallest injectable dose of insulin when using the patch is 0.05 U. The Profile BAS should therefore be set at a minimum value of 0.05 U/hr or more and an interval of 0.05 U/hr, as otherwise there may be an error between the estimated total infusion amount in the Profile and the actual infusion amount in the patch. Likewise, the bolus must also be set and infused with a minimum infusion volume of 0.05 U.


### PR DESCRIPTION
remark that EOPatch2 is panned feature for AndroidAPS 3.2 and therefore not in the actual version.