### PR TITLE
[minor] Changed xDrip source name for libre 2

### DIFF
--- a/docs/EN/Hardware/Libre2.md
+++ b/docs/EN/Hardware/Libre2.md
@@ -163,7 +163,7 @@ The blood sugar values are received on the smartphone by the xDrip+ App.
 -   If not already set up then download xDrip+ app and install one of
     the latest nightly builds from
     [here](https://github.com/NightscoutFoundation/xDrip/releases).
--   In xDrip+ select "Libre2 (patched App)" as data source
+-   In xDrip+ select "Libre2 patched" or "Libre 2 (patched App)" as data source
 -   If necessary, enter "BgReading:d,xdrip libre_receiver:v" under Less
     Common Settings->Extra Logging Settings->Extra tags for logging.
     This will log additional error messages for trouble shooting.


### PR DESCRIPTION
In the newest version, the source for libre 2 patched app has been renamed to libre2 patched