### PR TITLE
Added COB absorption explanation and example

### DIFF
--- a/docs/EN/Usage/COB-calculation.md
+++ b/docs/EN/Usage/COB-calculation.md
@@ -2,6 +2,12 @@
 
 ## How does AAPS calculate the COB value?
 
+When carbs are entered as part of a meal or correction, AAPS adds them to the current carbs on board (COB). AAPS then absorbs (removes) carbs based on observed deviations to BG values. The rate of absorption depends on the carb sensitivity factor. This is not a profile value but is calculated as ISF/IC and is how many mg/dl 1g of carbs will raise your BG. 
+
+For example, if your profile ISF is 100 and your IC is 5, your CSF would be 20. For every 20 mg/dl your BG goes up, 1g of carbs are absorbed by AAPS. Positive IOB also effects this calculation. So, if AAPS expected your BG to go down by 20 mg/dl because of IOB and it instead stayed flat, it would also absorb 1g of carbs.
+
+Carbs will also be absorbed via the methods described below based on what sensitivity algorithm is used. 
+
 ### Oref1
 
 Unabsorbed carbs are cut off after specified time


### PR DESCRIPTION
Previously, the first content in the COB section was the exception case of how the different sensitivity algorithms handled carbs that stayed on board too long. Adding this section to explain how COB are absorbed in normal circumstances.