### PR TITLE
Add a section: AAPS does not support 0 basal rate in profile

### DIFF
--- a/docs/EN/Configuration/OmnipodDASH.md
+++ b/docs/EN/Configuration/OmnipodDASH.md
@@ -48,6 +48,9 @@ As long as AAPS is operational it will send basal rate commands that run for a m
 **The AAPS Profile does not support a 30 minute basal rate time frame**
 If you are new to AAPS and are setting up your basal rate profile for the first time, please be aware that basal rates starting on a half-hour basis are not supported, and you will need to adjust your basal rate profile to start on the hour. For example, if you have a basal rate of 1.1 units which starts at 09:30 and has a duration of 2 hours ending at 11:30, this will not work. You will need to change this 1.1 unit basal rate to a time range of either 9:00-11:00 or 10:00-12:00. Even though the Omnipod Dash hardware itself supports the 30 min basal rate profile increments, AAPS is not able to take them into account with its algorithms currently.
 
+**0U/h profile basal rates are NOT supported in AAPS**
+While the DASH pods do support a zero basal rate, since AAPS uses multiples of the profile basal rate to determine automated treatment it cannot function with a zero basal rate. A temporary zero basal rate can be achieved through the "Disconnect pump" function or through a combination of Disable Loop/Temp Basal Rate or Suspend Loop/Temp Basal Rate. 
+
 ## Enabling the Dash Driver in AAPS
 
 You can enable the Dash driver in AAPS in **two ways**:


### PR DESCRIPTION
This ends up being a common question from people coming from Dash PDM because it does support a 0u/h basal rate. This is sometimes used by young kids or those going through a strong honeymooning phase.