### PR TITLE
Keep phone on the kid

### DIFF
--- a/docs/EN/Children/Children.md
+++ b/docs/EN/Children/Children.md
@@ -30,3 +30,4 @@ AAPS offer several options for remote monitoring of children and also allows to 
 - So take your time to set those correctly and test them in real life with your kid next to you before starting remote monitoring and remote treatment. School holidays might be a good time for that.
 - What is your emergency plan when remote control does not work (i.e. network problems)?
 - Remote monitoring and treatment can be really helpful in kinder garden and elementary school. But make sure the teachers and educators are aware of your kid's treatment plan. Examples for such care plans can be found in the [files section of AAPS users](https://www.facebook.com/groups/AndroidAPSUsers/files/) on Facebook.
+- It is important to keep the kid's phone in range of their pump and CGM at all times. This can be challenging especially with very small children. Many solutions exist, a popular option is an [SPI Belt](https://spibelt.com/collections/kids-belts)


### PR DESCRIPTION
AAPS increases the importance of keeping the kid's phone near them and should be pointed out to parents who may have previously just kept a CGM linked phone or receiver "in the room". Added a popular option for keeping a phone on a small kid.