### PR TITLE
AAPSClient > NSClient

### DIFF
--- a/docs/EN/Children/SMS-Commands.md
+++ b/docs/EN/Children/SMS-Commands.md
@@ -184,8 +184,8 @@ Remote bolus is not allowed within 15 min (this value is editable only if 2 phon
 
 - TREATMENTS REFRESH
   \* Response: Refresh treatments from NS
-- AAPSClient RESTART
-  \* Response: AAPSClient RESTART 1 receivers
+- NSClient RESTART
+  \* Response: NSCLIENT RESTART SENT
 - PUMP
   \* Response: Last conn: 1 min ago Temp: 0.00U/h @11:38 5/30min IOB: 0.5U Reserv: 34U Batt: 100
 - PUMP CONNECT


### PR DESCRIPTION
Looks like NSClient got overwritten by AAPSClient but SMS commands have not been changed yet. Pushing back the documentation until that is changed.