### PR TITLE
Replace dead link (https://seemycgm.com/) with archive.org snapshot

### DIFF
--- a/docs/EN/Where-To-Go-For-Help/Background-reading.md
+++ b/docs/EN/Where-To-Go-For-Help/Background-reading.md
@@ -10,7 +10,7 @@ Before you build your rig, you're going to have to do a lot of reading in order 
 
 [Loop Docs - https://loopkit.github.io/loopdocs/](https://loopkit.github.io/loopdocs/)
 
-[Fine-Tuning your settings - https://seemycgm.com/2017/10/29/fine-tuning-settings/](https://seemycgm.com/2017/10/29/fine-tuning-settings/)
+[Fine-Tuning your settings - https://web.archive.org/web/20231130035337/https://seemycgm.com/2017/10/29/fine-tuning-settings/](https://web.archive.org/web/20231130035337/https://seemycgm.com/2017/10/29/fine-tuning-settings/)
 
 [Tim Omer – Hypodiabetic Blog - https://www.hypodiabetic.co.uk/](https://www.hypodiabetic.co.uk/)
 


### PR DESCRIPTION
I noticed that the https://seemycgm.com/ website is no longer accessible. I adjusted the link in the documentation to include the archive.org snapshot of the website.