### PR TITLE
Create conf.py

### DIFF
--- a/docs/CROWDIN/zh_TW/conf.py
+++ b/docs/CROWDIN/zh_TW/conf.py
@@ -1,0 +1,3 @@
+import os
+
+exec (open("../../shared.conf.py").read())


### PR DESCRIPTION
The conf.py file is needed too even if it only points to directory upwards to the file shared.conf.py