### PR TITLE
Update crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,7 @@
 files:
   - source: /docs/EN/**/*.md
     translation: /docs/CROWDIN/%two_letters_code%/**/%original_file_name%
+    type: md35
   - source: /docs/EN/**/*.rst
     translation: /docs/CROWDIN/%two_letters_code%/**/%original_file_name%
   - source: /docs/EN/images/**/*


### PR DESCRIPTION
A small update to the configuration file related to Crowdin - GitHub connector that allows to upload .md files using the previous parser type. That allows to parse MD formatting as HTML tags, for example: https://crowdin.com/editor/androidapsdocs/96/en-fr?view=comfortable#63654

If "type" is not defined, then the latest `md36` parser is applied and Markdown syntax is used for formatting