### PR TITLE
Update SmoothingBloodGlucoseData.md

### DIFF
--- a/docs/EN/CompatibleCgms/SmoothingBloodGlucoseData.md
+++ b/docs/EN/CompatibleCgms/SmoothingBloodGlucoseData.md
@@ -26,8 +26,8 @@ Use this option only if your CGM data is being properly smoothed by your collect
 
 |                           | Exponential | Average  |    None     |
 |---------------------------|:-----------:|:--------:|:-----------:|
-| G5 and G6                 |             | If noisy | Recommended |
-| G7                        | Recommended |          |             |
+| G5 and G6                 | If noisy    |          | Recommended |
+| G7                        | If noisy    | If stable|             |
 | Libre 1 or Juggluco       | Recommended |          |             |
 | Libre 2 and 3 from xDrip+ |             |          | Recommended |
 


### PR DESCRIPTION
* Add Average as an option for G7 since it works very well, especially if sensor is stable
* G6 got internal backsmoothing (which is about same as average smoothing) so if G6 is very noisy, it make sense to use Exponential smoothing, average smoothing got no effect almost on G6.