### PR TITLE
WhereCanIGetHelp: add Russian AAPS Telegram group

### DIFF
--- a/docs/EN/GettingHelp/WhereCanIGetHelp.md
+++ b/docs/EN/GettingHelp/WhereCanIGetHelp.md
@@ -46,6 +46,9 @@ Join the main [AndroidAPS Facebook group](https://www.facebook.com/groups/190019
 ### Poland
 * [AndroidAPS Polska](https://www.facebook.com/groups/aapspl): Polish AAPS community and diabetes support group)
 
+### Russia
+* [AndroidApsGroup](https://t.me/androidapsgroup): Russian-speaking AAPS community where you can get support and general info on looping with AAPS
+
 ### Sweden
 *  [Looped Sweden](https://www.facebook.com/groups/661514380864081/) (Sweden based users of OpenAPS, Loop and AndroidAPS)
 


### PR DESCRIPTION
The only thing wrong with this chat is that it shares link to the channel with pre-built AAPS APKs. But it has got a lot of important info on looping and a massive amount of very experienced Russian loopers, who actively help newbies. FB and Discord are banned in our country, so that's the only AAPS group we have.

I'll just leave this PR here for your review, not looking forward to seeing this merged cause of the aforementioned issue.