### PR TITLE
Fix what buttons are visible when connection to pump is lost

### DIFF
--- a/docs/EN/DailyLifeWithAaps/AapsScreens.md
+++ b/docs/EN/DailyLifeWithAaps/AapsScreens.md
@@ -345,7 +345,7 @@ It is a good combination to display this line along with the Deviation bars. The
 
 ![Homescreen buttons](../images/Home2020_Buttons.png)
 
-Buttons for Insulin, Carbs and Calculator are almost always visible. If the connection to the pump is lost, the insulin button will not be visible.
+Buttons for Insulin and Carbs are almost always visible. If the connection to the pump is lost, the Calculator button will not be visible.
 
 Other Buttons can be setup in [Preferences > Overview > Buttons](#Preferences-buttons).
 


### PR DESCRIPTION
The current version of AAPS does not have the Calculator button available when a pump is not connected / connection is lost. The buttons always visible are the Insulin and Carbs.

![aaps_home_screen-3 3 1 3](https://github.com/user-attachments/assets/c9925136-fcd0-4010-80ec-aaf8b5ea449e)
