### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Detail of broken links in the doc can be found in the build logs. Select a build
 
 ### 1) Change language
 
-[Change language](https://androidaps.readthedocs.io/en/latest/ChangeLanguage/ChangeLanguage.html)
+[Change language](https://androidaps.readthedocs.io/en/latest/NavigateDoc/ChangeLanguage.html)
 
 ### 2) Getting started
 


### PR DESCRIPTION
Fix the broken link in README.md.
(I'm from https://github.com/material-components/material-components-android/issues/4373.)