### PR TITLE
Enable documentation downloads via formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,5 @@ sphinx:
   builder: html
   fail_on_warning: false
   configuration: docs/EN/conf.py
+
+formats: all


### PR DESCRIPTION
ReadTheDocs typically lets you download the entire documentation repository as a pdf / offline html zip file via the 'formats' option documented here: https://docs.readthedocs.com/platform/stable/config-file/v2.html#formats

It'd be helpful to me, at least, to be able to download a PDF of the entire AndroidAPS documentation and control-F through it from time to time. This should only require adding this option, and then the Read the Docs ui at the bottom right of the documentation page includes a "Downloads" section: 
<img width="264" height="308" alt="image" src="https://github.com/user-attachments/assets/cc565c87-1e0a-4d1d-9fda-623ad3a2fdff" />
