### PR TITLE
Add command line method for transferring wear apk to smartwatch

### DIFF
--- a/docs/EN/WearOS/WearOsSmartwatch.md
+++ b/docs/EN/WearOS/WearOsSmartwatch.md
@@ -78,9 +78,13 @@ a)	using a USB cable to put the **AAPS** wear apk file onto the phone, and then 
 b)	cut and paste Wear.apk from Android Studio onto your Gdrive.
 
 
-You can use either Wear Installer 2 or Easy Fire tools to side-load AAPS onto the watch. Here we recommend Wear Installer 2, because the instructions and process in the video are so clear and well-explained.  
+To side-load AAPS onto the watch You can use either:
+1) Wear Installer 2
+2) Easy Fire tools
+3) Android Debug Bridge (ADB)
+Here we recommend Wear Installer 2, because the instructions and process in the video are so clear and well-explained. If Wear Installer 2 does not work for you try via   
 
-## Using Wear Installer 2 to side-load **AAPS** Wear from the phone onto the watch
+### Using Wear Installer 2 to side-load **AAPS** Wear from the phone onto the watch
 
  ![image](../images/43577a66-f762-4c11-a3b3-4d6d704d26c7.png)
 
@@ -97,8 +101,7 @@ As mentioned in the video, once complete, switch ADB debugging off on the watch,
 
 Alternatively, but not for Wear OS 5, you can:
 
-```{admonition} Use Easy Fire tools to side-load the **AAPS** wear on the watch
-:class: dropdown
+### Use Easy Fire tools to side-load the **AAPS** wear on the watch 
 
 1)	 Download _Easy Fire Tools_ from playstore onto phone 
 
@@ -135,9 +138,45 @@ Click side "plug-in" socket in the app, in order to upload Wear OS.apk onto the 
 
 ![image](../images/2c398a34-b865-4aa1-9c53-d83dfef052a7.png)
 
-```
 
 (BuildingAapsWearOs-WearOS5-TShoot)=
+
+### Using the terminal
+Connect your smartwatch and computer to the same wifi network. 
+
+- To install ADB download it from:
+https://developer.android.com/tools/releases/platform-tools
+- Open a terminal.
+- After installation of ADB for windows set the path to the folder where ADB is located:
+```setx PATH "%PATH%;C:\platform-tools"```
+- For Mac instead of installing manually you can use homebrew:
+`brew install android-platform-tools`
+
+On the watch:
+- Go to Settings → About watch → **Software Information**
+- Tap Software version 7 times until you see Developer mode enabled.
+- Go to Settings → Developer options. Enable **ADB debugging**
+- Go to Settings → Developer options → Wireless debugging → **Pair new device** 
+
+You will see a wifi pariing code and ipaddress and port appearing:
+<img width="689" height="400" alt="Screenshot 2025-12-21 at 17 46 42" src="https://github.com/user-attachments/assets/9b73869a-e4ca-47e6-9ac4-37ecc20182e1" />
+- In the terminal:
+`adb pair ipaddress:port`
+E.g.
+`adb pair 10.10.1.125:36443`
+- You will be asked for the pairing code. Enter it. 
+- You will see a response:<br>
+`Successfully paired to 10.10.1.125:36443 [guid=adb-RXXXW20LMKJY-eh5zBj]`<br>
+- In the terminal type: <br>`adb devices`.<br> You should see something like:<br>
+`List of devices attached`<br>
+`10.10.1.125:45559	offline`<br>
+`adb-RFAW20LMKJY-eh5zBj._adb-tls-connect._tcp	device`<br>
+
+- Now go to the folder on your computer where the Wear apk is and type<br>
+`adb install wear-full.apk` <br>with wear.apk replaced by the name of your apk file.
+- You will see:<br>
+`Performing Streamed Install`<br> `Success`
+
 
 ### General troubleshooting recommendations for Wear OS 5
 


### PR DESCRIPTION
Add CL method for transfering wear-apk to smartwatch. 

Ive noticed that Easy fire tool and Wear installer can be a bit cumbersome sometimes. Although it requires the cli, this method seems to be a reliable quick method for transfering the apk. 

I have not tested this on windows as I dont have access to a windows machine.