### PR TITLE
Remove Treatments section from ConfigBuilder docs

### DIFF
--- a/docs/EN/SettingUpAaps/ConfigBuilder.md
+++ b/docs/EN/SettingUpAaps/ConfigBuilder.md
@@ -198,8 +198,7 @@ Broadcast data to Samsung's G-Watch Wear App (Tizen OS).
 ### Garmin
 
 Connection to Garmin device (Fenix, Edge...)
-## Treatments
-If you view the Treatments (Treat) tab, you can see the treatments that have been uploaded to nightscout.  Should you wish to edit or delete an entry (e.g. you ate less carbs than you expected) then select 'Remove' and enter the new value (change the time if necessary) through the [carbs button on the home screen](#screens-bolus-carbs).
+
 
 ## General
 


### PR DESCRIPTION
AFAIU, the Treatments have moved to a dedicated required screen and a few years ago and are now described here: https://androidaps.readthedocs.io/en/latest/DailyLifeWithAaps/AapsScreens.html#treatments

There might be more outdated info on this page BTW, especially at the bottom.