### PR TITLE
Add internal links to the glossary and minor edits

### DIFF
--- a/docs/EN/DailyLifeWithAaps/AapsScreens.md
+++ b/docs/EN/DailyLifeWithAaps/AapsScreens.md
@@ -305,6 +305,7 @@ Most users find the following configuration of additional graphs to be adequate 
 
 Active insulin including boluses **and basal**.
 
+(aaps-screens-iob)=
 #### Insulin on board (IOB)
 
 Shows the insulin you have on board (= active insulin in your body). It includes insulin from bolus and temporary basal (**but excludes basal rates set in your profile**).

--- a/docs/EN/DailyLifeWithAaps/KeyAapsFeatures.md
+++ b/docs/EN/DailyLifeWithAaps/KeyAapsFeatures.md
@@ -228,6 +228,7 @@ Default value : the same as **Max minutes of basal to limit SMB**.
 
 This setting is only visible if "Enable SMB" and "Enable UAM " are switched on.
 
+(enable-uam)=
 ### Enable UAM
 With this option enabled, the SMB algorithm can recognize unannounced meals. This is helpful if you forget to tell **AAPS** about your carbs or estimate your carbs wrong and the amount of entered carbs is wrong or if a meal with lots of fat and protein has a longer duration than expected. Without any carb entry, UAM can recognize fast glucose increase caused by carbs, adrenaline, etc., and tries to adjust it with SMBs. This also works the opposite way: if there is a fast glucose decrease, it can stop SMBs earlier.
 

--- a/docs/EN/UsefulLinks/BackgroundReading.md
+++ b/docs/EN/UsefulLinks/BackgroundReading.md
@@ -20,9 +20,9 @@ Before you build your rig, you're going to have to do a lot of reading in order 
 
 [OpenAPS Reference Design - https://openaps.org/reference-design/](https://openaps.org/reference-design/)
 
-[Why we are regularly wrong in the duration of insulin action (DIA) times we use, and why it matters - https://www.diabettech.com/insulin/why-we-are-regularly-wrong-in-the-duration-of-insulin-action-dia-times-we-use-and-why-it-matters/](https://www.diabettech.com/insulin/why-we-are-regularly-wrong-in-the-duration-of-insulin-action-dia-times-we-use-and-why-it-matters/)
+[Why we are regularly wrong in the duration of insulin action (DIA) times we use, and why it matters](https://www.diabettech.com/why-we-are-regularly-wrong-in-the-duration-of-insulin-action-dia-times-we-use-and-why-it-matters/)
 
-[What conclusions can we draw when investigating Insulin Sensitivity using the Autosens function within #OpenAPS? https://www.diabettech.com/openaps/what-conclusions-can-we-draw-when-investigating-insulin-sensitivity-using-the-autosens-function-within-openaps-an-n1-study/](https://www.diabettech.com/openaps/what-conclusions-can-we-draw-when-investigating-insulin-sensitivity-using-the-autosens-function-within-openaps-an-n1-study/)
+[What conclusions can we draw when investigating Insulin Sensitivity using the Autosens function within #OpenAPS?](https://www.diabettech.com/what-conclusions-can-we-draw-when-investigating-insulin-sensitivity-using-the-autosens-function-within-openaps-an-n1-study/)
 
 [https://seemycgm.com/2017/10/29/fine-tuning-settings/](https://web.archive.org/web/20231130035337/https://seemycgm.com/2017/10/29/fine-tuning-settings/)
 

--- a/docs/EN/UsefulLinks/Glossary.md
+++ b/docs/EN/UsefulLinks/Glossary.md
@@ -2,7 +2,9 @@
 
  __AAPS__ =  AndroidAPS is the name of the Android app.
 
-__AAPSClient__ (or __NSClient__) = a remote control feature that can be used by caregivers via a follower phone to follow a user’s __AAPS__ by connecting to the user’s __Nightscout's__ site. Further info → Wiki - 'NS Client'. Objectives learning program within __AAPS__ provides step by step guidance. Further info → Wiki - 'objectives'.
+__AAPSClient__ (or __NSClient__) = a remote control feature that can be used by caregivers via a follower phone to follow a user’s __AAPS__ by connecting to the user’s __Nightscout's__ site. Further info → [Wiki - 'The AAPSClient app'](../RemoteFeatures/AapsClient.md). Objectives learning program within __AAPS__ provides step by step guidance. Further info → [Wiki - 'objectives'](../SettingUpAaps/CompletingTheObjectives.md).
+
+__Activity__ = Insulin activity, representing the speed of decay of IOB. See [Wiki - 'DIA'](#Config-Builder-insulin-dia) and the related __BGI__.
 
 __AID__ = Automated Insulin Delivery.
 The term generally used in clinical practice and research for a system which automatically adjusts insulin delivery using __CGM__ data. __APS__ and __closed loop__ mean the same thing → see also __OS-AID__.
@@ -10,18 +12,16 @@ The term generally used in clinical practice and research for a system which aut
 __APS__ = Artificial Pancreas System → see also __AID__.
 
 __AMA__ = Advanced Meal Assist.
-An algorithm which allows __AAPS__ to increase the user’s basal more aggressively after a meal bolus. Further info → Wiki - 'AMA'.
+An algorithm which allows __AAPS__ to increase the user’s basal more aggressively after a meal bolus. Further info → [Wiki - 'Advanced Meal Assist (AMA)'](#Open-APS-features-advanced-meal-assist-ama).
 
-__Adjustment Factor__ = used within **DynamicISF** and is a value set within a user's **Preferences** between 1% and 300%. This acts as a multiplier on the **TDD** value.
-- increasing the **Adjustment Factor** value above 100 % makes **DynamicISF** more aggressive: the **ISF** values become smaller (i.e. more insulin required to decrease **BG** levels a small amount)
-- lowering the **Adjustment Factor** value under 100% makes **DynamicISF** less aggressive: the **ISF** values become larger (i.e. less insulin required to decrease **BG** levels a small amount).
+__Adjustment Factor__ = used within **DynamicISF** and is a value set within a user's **Preferences** between 1% and 300%. This acts as a multiplier on the **TDD** value. See [Wiki - DynamicISF adjustment factor](#dyn-isf-adjustment-factor)
 
-__Android Auto__ = a system used to host certain functions of an Android smartphone’s features, including __AAPS__, within a car's display. Further info → Wiki - 'android auto'.
+__Android Auto__ = a system used to host certain functions of an Android smartphone’s features, including __AAPS__, within a car's display. Further info → [Wiki - 'android auto'](../RemoteFeatures/AndroidAuto.md).
 
 __APK__ = Android application Package. 
-A software installation file.  Further info → Wiki - 'Building APK'.
+A software installation file.  Further info → [Wiki - 'Building APK'](../SettingUpAaps/BuildingAaps.md).
 
-__Autosens__ = calculation of sensitivity to insulin between a period of a 24 and 8 hour window etc. Further info → DIABETTECH - __Autosens__.
+__Autosens__ = calculation of sensitivity to insulin between a period of a 24 and 8 hour window etc. Further info → [DIABETTECH - __Autosens__](https://www.diabettech.com/what-conclusions-can-we-draw-when-investigating-insulin-sensitivity-using-the-autosens-function-within-openaps-an-n1-study/).
 
 __Azure__ = cloud computing platform to host __Nightscout__ web app Azure → see also __Nightscout__.
 
@@ -32,7 +32,7 @@ __BG__ =  blood glucose.
 __BGI__ = blood glucose impact.
 The degree to which __BG__ 'should' rise or fall based on insulin activity alone.
 
-__BG source__ = the source of the user’s __BG__ values derived from either __CGM__ or __FGM__ through a system integration software like __BYODA__, __xDrip__ etc. Further info → Wiki - 'BG source'
+__BG source__ = An AAPS setting for configuring the source for blood glucose data. See [Wiki - BG Source](#Config-Builder-bg-source)
 
 __Bridge__ = an additional device transforming __FGM__ to __CGM__.  
 
@@ -57,17 +57,14 @@ This is the amount of carbohydrates currently available for the user's digestion
 __CSF__ =Carbs Sensitivity Factor.
 i.e. how much does the user’s __BG__ increase for 1g of carbs absorbed.
 
-__DIA__ = Duration of Insulin Action.  Further info →  Wiki - 'insulin types' and see also →  DIABETTECH - 'DIA'.
+__DIA__ = Duration of Insulin Action.  Further info →  [Wiki - 'DIA'](#Config-Builder-insulin-dia) and see also →  [DIABETTECH - 'DIA'](https://www.diabettech.com/why-we-are-regularly-wrong-in-the-duration-of-insulin-action-dia-times-we-use-and-why-it-matters/).
 
-__DST__ = Daylight Savings Time Wiki DST.
+__DST__ = Daylight Savings Time. See [Wiki - Timezone Change and Daylight Saving](../DailyLifeWithAaps/TimezoneTraveling-DaylightSavingTime.md).
 
-__Dynamic ISF (or DynISF)__ =  a feature within **AAPS** that adapts the insulin sensitivity factor (**ISF**) dynamically based on the user’s:
-- Total Daily Dose of insulin (**TDD**); and
-- current and predicted **BG** values.
-
+__Dynamic ISF (or DynISF)__ =  a feature within **AAPS** that adapts the insulin sensitivity factor (**ISF**) dynamically based on the user’s **TDD** and **BG**.
 
 __eCarbs__ = extended Carbs.
-Carbs split up over several hours to accommodate/protein and permits __AAPS__ to deliver extended boluses.  Further info →  Wiki - 'eCarbs', 'eCarbs use'.
+Carbs split up over several hours to accommodate/protein and permits __AAPS__ to deliver extended boluses.  Further info → [Wiki - 'Extended Carbs'](../DailyLifeWithAaps/ExtendedCarbs.md)
 
 __FCL__ = Full Closed Loop.
 A loop which needs no mealtime input from the user: no carb counting and no meal bolus. Further info → Wiki - 'full closed loop' and see also __HCL__.
@@ -84,33 +81,29 @@ __Glimp__ = an app to collect values from Freestyle Libre Glimp.
 
 __HCL (or Hybrid Closed Loop)__ = a loop which automates insulin delivery between meals, but still requires the user to bolus for meals. Nearly every system in everyday use, including __AAPS__, is a hybrid closed loop → see also __FCL__ / __Closed Loop__.
 
-__IC (or I:C)__ = Insulin to Carb ratio. 
-(i.e. how many carbs are covered by one unit of insulin?).
+__IC (I:C, ICR, CR, carb ratio)__ = Insulin to Carb ratio. Note that this is conventionally g/U despite the acronym suggesting inverse.
 
 __IOB__ = Insulin On Board.
-Insulin active in the user’s body.
+Insulin active in the user’s body. See [Wiki - Insulin on Board](#aaps-screens-iob)
 
 __ISF__ = Insulin Sensitivity Factor.
-The expected decrease in BG as a result of one unit of insulin.
+The expected decrease in BG as a result of one unit of insulin. Unit is either mg/dL/U or mmol/L/U. These are not equivalent without a conversion!
 
 __Keystore (or JKS)__ = a Java Key Store which is an encrypted file where your personal developer certificates and keys will be stored required for your __AAPS'__ build (and rebuid).
 
-__LGS__ = Low Glucose Suspend. 
-__AAPS__ will reduce basal if __BG__ is dropping and if __BG__ is rising, then it will only increase basal if  __IOB__ is negative (from a previous __LGS__), otherwise basal rates will remain the same as the user’s selected __Profile__. The user may temporarily experience spikes following treated hypos without the ability to increase basal on the rebound. → see also objective 6.
+__LGS__ = Low Glucose Suspend. See [Wiki - Low Glucose Suspend](#KeyAapsFeatures-LGS)
 
-__LineageOS__ = free and open-source operating system for smartphones etc. 
-(When using Accu-Chek Combo see Wiki - Combo pump).
+__LineageOS__ = free and open-source operating system for smartphones etc. When using Accu-Chek Combo see [Wiki - Combo pump](../CompatiblePumps/Accu-Chek-Combo-Pump-v2.md).
 
-__Log files__ = __AAPS’__ records of the user's actions (useful for troubleshooting and debugging). Further info →  Wiki - 'log files'.
+__Log files__ = __AAPS’__ records of the user's actions (useful for troubleshooting and debugging). Further info →  [Wiki - 'log files'](../GettingHelp/AccessingLogFiles.md).
 
 __maxIOB__ = maximum total IOB.
-This is a safety feature and prevents __AAPS__ delivering insulin over the user’s settings.  Further info →  Wiki - 'SMB'.
+This is a safety feature and prevents __AAPS__ delivering insulin over the user’s settings.  Further info →  [Wiki - 'Maximum total IOB OpenAPS can’t go over'](#Open-APS-features-maximum-total-iob-openaps-cant-go-over).
 
-__min_5m_carbimpact__ = safety feature that is a calculation of default carb decay when carb absorption cannot be determined based on the user’s blood’s reactions. 
-This is a safety feature.  Further info →  Wiki - 'config builder'.
+__min_5m_carbimpact__ = safety feature that is a calculation of default carb decay when carb absorption cannot be determined based on the user’s blood’s reactions. Further info →  [Wiki - 'Preferences'](#Preferences-min_5m_carbimpact).
 
 __Nightscout__ = open source project to access and report __CGM__ data. 
-The central data hub for the user’ __AAPS__ data and can generate reports to view the user’s historical __NIghtscout__ data expected HbA1c, time in range) or search for patterns in the data via percentile chart etc. 
+The central data hub for the user’ __AAPS__ data and can generate reports to view the user’s historical __Nightscout__ data expected HbA1c, time in range or search for patterns in the data via percentile chart etc. 
 
 __Nightscout__ → see also __Nightscout Reporter__. This is particularly useful for parents following their child's diabetes management.
 
@@ -118,24 +111,24 @@ __Nightscout Reporter Tool__ = a tool which generates PDFs reports from Nightsco
 
 __NSClient__ ( or __‘AAPSClient’)__ = see __AAPSClient__.
 
-__OpenAPS__ = Open Artificial Pancreas System.
+__OpenAPS__ = Open Artificial Pancreas System, the predecessor project and basis of AAPS.
 
-__Open Loop system__ = an __AAPS__ feature that will recommend adjustments and which must be performed manually by the user on __AAPS__.  Further info →  Wiki - 'config builder'.
+__Open Loop system__ = an __AAPS__ feature that will recommend adjustments and which must be performed manually by the user on __AAPS__.  Further info →  [Wiki - 'Open Loop'](#KeyAapsFeatures-OpenLoop).
 
 __Oref0 / Oref1__ = sensitivity detection and "reference design implementation version 0/1". It is the key algorithm behind OpenAPS Wiki - sensitivity detection.
 
 __OS-AID__ = Open-Source Automated Insulin Delivery.
 An __AID__ system built from open-source software, such as __AAPS__, __OpenAPS__, Loop or Trio. These systems are not formally approved by health bodies (FDA, NHS etc.) → see also __AID__.
 
-__Peak time__ = time of maximum effect of insulin given. Further info → Wiki - 'config builder'.
+__Peak time__ = time of maximum effect of insulin given. Further info → [Wiki - 'Duration of insulin action (DIA) and peak'](#Config-Builder-insulin-dia).
 
 __PH__ = Pump History. 
 This can be accessed in __AAPS’__ treatments which are located on the 3 dot menu on the right side of __AAPS__ main screen Screenshots.
 
-__Predictions__ = predictions for __BG__ in the future based on different calculations. Further info → Wiki - 'prediction lines'.
+__Predictions__ = predictions for __BG__ in the future based on different calculations. Further info → [Wiki - 'prediction lines'](#aaps-screens-prediction-lines).
 
 __Profile__ = the user’s basic treatment settings (basal rate, __DIA__, __IC__, __ISF__, __BG__ target).
-AAPSv3 only supports local profiles created within __AAPS__ but __Nightscout__ __Profiles__ can be copied (synchronised) to __AAPS__. Further info → Wiki - 'profile'.
+AAPSv3 only supports local profiles created within __AAPS__ but __Nightscout__ __Profiles__ can be copied (synchronised) to __AAPS__. Further info → [Wiki - 'Your AAPS profile'](../SettingUpAaps/YourAapsProfile.md).
 
 __Profile switch__ = (temporary) switch  of the user’ __Profile__ to a different __Profile__ saved within __AAPS__.
 
@@ -150,12 +143,12 @@ This is displayed on the main screen of __AAPS__ and in __Nightscout__, based on
 
 __SEN__ = status light for overdue sensor change, shown in the status row of __AAPS'__ main screen → see also __BAT__ / __CAN__ / __RES__.
 
-__Sensivity detection__ = calculation of sensitivity to insulin as a result of exercise, hormones etc.  see also → DIABETTECH - 'Autosens'.
+__Sensivity detection__ = calculation of sensitivity to insulin as a result of exercise, hormones etc.  see also → [DIABETTECH - 'Autosens'](https://www.diabettech.com/what-conclusions-can-we-draw-when-investigating-insulin-sensitivity-using-the-autosens-function-within-openaps-an-n1-study/).
 
-__Sensor noise__ = a term used to describe the unstable __CGM’s__ readings leading to "jumping" __BG__ values.  Further info → Wiki - 'sensor noise'.
+__Sensor noise__ = a term used to describe the unstable __CGM’s__ readings leading to "jumping" __BG__ values.  Further info → [Wiki - 'Smoothing blood glucose data'](../CompatibleCgms/SmoothingBloodGlucoseData.md).
 
 __SMB__ = Super Micro Bolus.
-An __AAPS__ feature for faster insulin delivery in order to adjust __BG__.  Further info → Wiki - '__SMB__' and  see also __UAM__.
+An __AAPS__ feature for faster insulin delivery in order to adjust __BG__.  Further info → [Wiki - '__SMB__'](#Open-APS-features-super-micro-bolus-smb) and  see also __UAM__.
 
 __Super bolus__ = shift of basal to bolus insulin for faster __BG__ adjustment.
 
@@ -165,10 +158,10 @@ __TBR__ = temporary basal rate→ see also __TBB__ / __TDD__.
 
 __TDD__ = total daily dose (bolus + basal per day) → see also __TBB__ / __TBR__.
 
-__TT__ = temporary target temporary increase/decrease of the user’s __BG__ target (range) e.g. for eating or sport activities.  Further info → Wiki - 'temp targets'.
+__TT__ = temporary target temporary increase/decrease of the user’s __BG__ target (range) e.g. for eating or sport activities.  Further info → [Wiki - 'temp targets'](../DailyLifeWithAaps/TempTargets.md).
 
 __UAM__ = unannounced meals. 
-Detection of significant increase in __BG__ levels due to meals, adrenaline or other influences and attempt to adjust this.  Further info → Wiki - 'UAM' and see also __SMB__.
+Detection of significant increase in __BG__ levels due to meals, adrenaline or other influences and attempt to adjust this.  Further info → [Wiki - 'UAM'](#enable-uam) and see also __SMB__.
 
 __Virtual pump__ = an __AAPS__ feature which allows the user to try __AAPS’__ functions or for PWD using a pump model with no __AAPS__ driver for looping → see also __Open Loop__.
 


### PR DESCRIPTION
Mostly new internal links but also minor touch-ups.

Mainly to:

* DIA
* activity
* adjustment factor
* ISF
* LGS
* IC

The deleted adjustment factor part was almost a copy from the main DynISF section. IMO this list works better with concise descriptions